### PR TITLE
Fix some links

### DIFF
--- a/Function-operators.rmd
+++ b/Function-operators.rmd
@@ -111,7 +111,7 @@ system.time(runif(100))
 system.time(delay_by(1, runif)(100))
 ```
 
-`dot_every` is a little bit more complicated because it needs to modify state in the parent environment using `<<-`. If it's not clear how this works, you might want to re-read the mutable state section in [[Functional programming]].
+`dot_every` is a little bit more complicated because it needs to modify state in the parent environment using `<<-`. If it's not clear how this works, you might want to re-read the mutable state section in [Functional programming](Functional-programming.html).
 
 ```{r}
 dot_every <- function(n, f) {
@@ -349,7 +349,7 @@ I often use this idea to make a `compact()` function that removes all null eleme
 compact <- function(x) Filter(Negate(is.null), x)
 ```
 
-`plyr::failwith()` turns a function that throws an error into a function that returns a default value when there's an error. Again, the essence of `failwith()` is simple, it's just a wrapper around `try()`, which captures errors and continues execution. (if you haven't seen `try()` before, it's discussed in more detail in the [[exceptions and debugging|Exceptions-debugging]] chapter):
+`plyr::failwith()` turns a function that throws an error into a function that returns a default value when there's an error. Again, the essence of `failwith()` is simple, it's just a wrapper around `try()`, which captures errors and continues execution. (if you haven't seen `try()` before, it's discussed in more detail in the [exceptions and debugging](Exceptions-Debugging.html) chapter):
 
 ```{r}
 failwith <- function(default = NULL, f, quiet = FALSE) {
@@ -435,7 +435,7 @@ In this example, there's not a huge benefit to using function operators, because
 
 * Create a FO that tracks files created or deleted in the working directory (Hint: use `setDiff()` and `dir()`).  What other global effects do functions have you might want to track?
 
-* Modify the final example to use `fapply()` from the [[functionals]] chapter instead of `lapply()`.
+* Modify the final example to use `fapply()` from the [functionals](Functionals.html) chapter instead of `lapply()`.
 
 ## Input FOs
 


### PR DESCRIPTION
Fix some links which destination is currently known. There are some links remaining in the original [[xxx]] style, but I don't know where to point them (specially the software system one, I suspect that the S3 one could go to the OO chapter, which seems to have been merged with the OO systems one)
