### PR TITLE
Switch from html to HTML to avoid inconsistent capping

### DIFF
--- a/dsl.rmd
+++ b/dsl.rmd
@@ -47,7 +47,7 @@ HTML is the language that underlies the majority of the web. It is a special cas
 </body>
 ```
 
-Even if you've never seen HTML before, hopefully you can see the key component of the structure: HTML is composed of tags that look like `<tag></tag>`. Tags can be contained inside other tags and intermingled with text. Generally, html ignores whitespace: an sequence of whitespace is equivalent to a single space. You could put the previous example all on online and it would still display the same in the browser:
+Even if you've never seen HTML before, hopefully you can see the key component of the structure: HTML is composed of tags that look like `<tag></tag>`. Tags can be contained inside other tags and intermingled with text. Generally, HTML ignores whitespace: an sequence of whitespace is equivalent to a single space. You could put the previous example all on online and it would still display the same in the browser:
 
 ```html
 <body><h1 id='first'>A heading</h1><p>Some text &amp; <b>some bold
@@ -57,7 +57,7 @@ text.</b></p><img src='myimg.png' width='100' height='100' />
 
 However, like R code, you usually want to indent HTML to make it more obvious to see the structure.
 
-There are over 100 html tags, but to illustrate HTML we're going to focus on just a few:
+There are over 100 HTML tags, but to illustrate HTML we're going to focus on just a few:
 
 * `<body>`: the top-level tag that all content is enclosed within
 * `<h1>`: creates a heading-1, the top level heading
@@ -71,11 +71,11 @@ Tags can also have named attributes that look like `<tag a="a" b="b"></tags>`. T
 
 Some tags, like `<img>`, can't have any content. These are called __void tags__ and have a slightly different syntax: instead of writing `<img></img>` you write `<img />`. Since they have no content, attributes are more imporant, and `img` has three that are used for almost every image: `src` (where the image lives), `width` and `height`.
 
-Because `<` and `>` have special meanings in html, you can't write them directly. Instead you have to use the html escapes `&gt;` and `&lt;`. And since those escapes use `&`, you also have to escape it with `&amp;` if you want a literal ampersand.
+Because `<` and `>` have special meanings in HTML, you can't write them directly. Instead you have to use the HTML escapes `&gt;` and `&lt;`. And since those escapes use `&`, you also have to escape it with `&amp;` if you want a literal ampersand.
 
 ### Goal
 
-Our goal is to make it easy to generate html from R. To give a concrete example, we want to generate the following html:
+Our goal is to make it easy to generate HTML from R. To give a concrete example, we want to generate the following HTML:
 
 ```html
 <body>
@@ -85,7 +85,7 @@ Our goal is to make it easy to generate html from R. To give a concrete example,
 </body>
 ```
 
-using code that looks as similar to the html as possible. We will work our way up to the following DSL:
+using code that looks as similar to the HTML as possible. We will work our way up to the following DSL:
 
 ```{r, eval = FALSE}
 with_html(body(
@@ -95,13 +95,13 @@ with_html(body(
 ))
 ```
 
-Note that the nesting of function calls is the same as the nesting of tags, unnamed arguments become the content of the tag, and named arguments become the attributes. Because tags and text are clearly distinct in this api, we can automatically escape `&` and other special characters.
+Note that the nesting of function calls is the same as the nesting of tags, unnamed arguments become the content of the tag, and named arguments become the attributes. Because tags and text are clearly distinct in this API, we can automatically escape `&` and other special characters.
 
 ### Escaping
 
-Escaping is so fundamental we're going to start with it. We first start by creating a way of escaping the characters that have special meaning for html, while making sure we don't end up double-escaping at any point. The easiest way to do this is to create an S3 class that allows us to distinguish between regular text (that needs escaping) and html (that doesn't).
+Escaping is so fundamental we're going to start with it. We first start by creating a way of escaping the characters that have special meaning for HTML, while making sure we don't end up double-escaping at any point. The easiest way to do this is to create an S3 class that allows us to distinguish between regular text (that needs escaping) and HTML (that doesn't).
 
-We then write an escape method that leaves html unchanged and escapes the special characters (`&`, `<`, `>`) in ordinary text. We also add a method for lists for convenience
+We then write an escape method that leaves HTML unchanged and escapes the special characters (`&`, `<`, `>`) in ordinary text. We also add a method for lists for convenience
 
 ```{r}
 html <- function(x) structure(x, class = "html")
@@ -126,7 +126,7 @@ escape("x > 1 & y < 2")
 # Double escaping is not a problem
 escape(escape("This is some text. 1 > 2"))
 
-# And text we know is html doesn't get escaped.
+# And text we know is HTML doesn't get escaped.
 escape(html("<hr />"))
 ```
 
@@ -134,7 +134,7 @@ Escaping is an important component for any dsl.
 
 ### Basic tag functions
 
-Next we'll write a few simple tag functions and then figure out how to generalise for all possible html tags. Let's start with `<p>`. HTML tags can have both attributes (e.g. id, or class) and children (like `<b>` or `<i>`). We need some way of separating these in the function call: since attributes are named values and children don't have names, it seems natural to separate using named vs. unnamed arguments. Then a call to `p()` might look like:
+Next we'll write a few simple tag functions and then figure out how to generalise for all possible HTML tags. Let's start with `<p>`. HTML tags can have both attributes (e.g. id, or class) and children (like `<b>` or `<i>`). We need some way of separating these in the function call: since attributes are named values and children don't have names, it seems natural to separate using named vs. unnamed arguments. Then a call to `p()` might look like:
 
 ```{r, eval = FALSE}
 p("Some text.", b("some bold text"), class = "mypara")
@@ -161,7 +161,7 @@ unnamed <- function(x) {
 }
 ```
 
-We can now create our `p()` function. There's one new function here: `html_attributes()`. This takes a list of name-value pairs and creates the correct html attributes specification from them. It's a little complicated (to deal with some idiosyncracies of html that I haven't mentioned), not that important and doesn't introduce any  new ideas, so I won't discuss it here, but it's included at the end of the chapter.
+We can now create our `p()` function. There's one new function here: `html_attributes()`. This takes a list of name-value pairs and creates the correct HTML attributes specification from them. It's a little complicated (to deal with some idiosyncracies of HTML that I haven't mentioned), not that important and doesn't introduce any  new ideas, so I won't discuss it here, but it's included at the end of the chapter.
 
 ```{r}
 source("code/html-attributes.r")
@@ -216,7 +216,7 @@ p("Some text.", b("Some bold text"), i("Some italic text"),
   class = "mypara")
 ```
 
-Before we continue to generate functions for every possible html tag, we need a variant of `tag()` for void tags. It can be very similar to `tag()`, but needs to throw an error if there are any unnamed tags, and the tag itself looks slightly different:
+Before we continue to generate functions for every possible HTML tag, we need a variant of `tag()` for void tags. It can be very similar to `tag()`, but needs to throw an error if there are any unnamed tags, and the tag itself looks slightly different:
 
 ```{r}
 void_tag <- function(tag) {
@@ -238,7 +238,7 @@ img(src = "myimage.png", width = 100, height = 100)
 
 ### Processing all tags
 
-Next we need a list of all the html tags:
+Next we need a list of all the HTML tags:
 
 ```{r}
 tags <- c("a", "abbr", "address", "article", "aside", "audio", "b", 
@@ -285,7 +285,7 @@ with_html <- function(code) {
 }
 ```
 
-This gives us a succinct API which allows us to write html when we need it without cluttering up the namespace when we don't. Inside `with_html` if you want to access the R function overridden by an html tag of the same name, you can use the full `package::function` specification.
+This gives us a succinct API which allows us to write HTML when we need it without cluttering up the namespace when we don't. Inside `with_html` if you want to access the R function overridden by an HTML tag of the same name, you can use the full `package::function` specification.
 
 ```{r}
 with_html(body(


### PR DESCRIPTION
Sometimes html was used, and sometimes HTML. Left only one html, as the sentence was referring to some html code, not the standard.
