### PR TITLE
Added Clarification in R CMD check section on test filename requirements...

### DIFF
--- a/Testing.rmd
+++ b/Testing.rmd
@@ -309,7 +309,7 @@ This promotes a workflow where the _only_ way you test your code is through test
 
 ## R CMD check
 
-When developing a package, put your tests in `inst/tests` and then create a file `tests/run-all.R` (note that it must be a capital R), which contains the following code:
+When developing a package, put your tests in `inst/tests` (note that your test files must begin with `test`), and then create a file `tests/run-all.R` (note that it must be a capital R), which contains the following code:
 
     library(testthat)
     library(mypackage)


### PR DESCRIPTION
....

It isn't clear from this section that all test files must begin with `test` or they won't be picked up by `tests/run-all.R`.
