### PR TITLE
fixed typo, then revised sentence for clarity

### DIFF
--- a/Package-development-cycle.rmd
+++ b/Package-development-cycle.rmd
@@ -31,9 +31,9 @@ The sections below describe useful practices for developing packages, where you 
 
 ## Dev mode
 
-When you're developing packages, typically you are developing them because you're using them - and that easily leads to confusion. When you're using a package for a data analysis or other project, you probably want to use the released version of the package- you don't want to use the possibly buggy or broken in-development version. But when you're developing and testing a package, you obviously want the development version.
+When you're developing packages, typically you are developing them because you're using them - and that easily leads to confusion. When you're doing data analysis, you want to use a stable version but when you are developing code, you want to make sure that you can test changes that you have made.
 
-The `dev_mode()` function makes it easier to managing this distinction.  When you're doing development you can run `dev_mode()` to switch to a special library where you can install and test new packages.  When you're doing regular work, you keep it off and R won't find the development packages:
+The `dev_mode()` function makes it easier to manage the distinction between stable and develpment versions of a package.  During development, the function `dev_mode()` will install the package in a special library that is not part of the default library path. Here, you can install and test new packages.  During analysis, you keep `dev_mode()` off and R won't find the development packages:
 
     # During development
     dev_mode()


### PR DESCRIPTION
The typo was "easier to manag_ing_ this distinction"

But while it was opened, I tried to make some text more concise, and explicit (e.g. converting "it" to "dev_mode()".

Please let me know if you would prefer that I stick to copy-edits rather than such revision.
