### PR TITLE
Update Vocabulary.rmd

### DIFF
--- a/Vocabulary.rmd
+++ b/Vocabulary.rmd
@@ -149,7 +149,7 @@ contrasts
 apropos("\\\.test$")
 
 # Random variables 
-(q, t, d, r) * (beta, binom, cauchy, chisq, exp, f, gamma, geom, 
+(q, p, d, r) * (beta, binom, cauchy, chisq, exp, f, gamma, geom, 
   hyper, lnorm, logis, multinom, nbinom, norm, pois, signrank, t, 
   unif, weibull, wilcox, birthday, tukey)
 


### PR DESCRIPTION
Small typo.
Corrected `t` to `p` as a prefix for a distribution function. (E.g. there is no `tbeta()` but there is a `pbeta()`.)
