### PR TITLE
Fixed typo

### DIFF
--- a/Functional-programming.rmd
+++ b/Functional-programming.rmd
@@ -83,7 +83,7 @@ for (i in seq_along(x)) {
 }
 ```
 
-The real `lapply()` is rather more complicated since it's implemented in C for efficiency, but the essence of the algorithm is the same. `lapply()` is called a __functional__, because it takes a function as an arguments. Functionals are an important part of functional programming and we'll learn more about them in the [[functionals]] chapter.
+The real `lapply()` is rather more complicated since it's implemented in C for efficiency, but the essence of the algorithm is the same. `lapply()` is called a __functional__, because it takes a function as an argument. Functionals are an important part of functional programming and we'll learn more about them in the [[functionals]] chapter.
 
 We can use `lapply()` with one small trick: rather than simply assigning the results to `df` we assign them to `df[]`, so R's usual subsetting rules take over and we get a data frame instead of a list. (If this comes as a surprise, you might want to read over the [[subsetting]] appendix)
 


### PR DESCRIPTION
Changed "because it takes a function as an arguments" to "because it takes a function as an argument"
