### PR TITLE
Fixing typo in subset2

### DIFF
--- a/Computing-on-the-language.rmd
+++ b/Computing-on-the-language.rmd
@@ -663,7 +663,7 @@ subset2 <- function(.data, subset) {
   sub <- eval(substitute(subset), .data, parent.frame())
   sub <- sub & !is.na(sub)
 
-  .data[r, , drop = FALSE]
+  .data[sub, , drop = FALSE]
 }
 arrange2 <- function (.data, ...) {
   ord <- eval(substitute(order(...)), .data, parent.frame())


### PR DESCRIPTION
`r` was used when `sub` was intended.
