### PR TITLE
Added adjective.

### DIFF
--- a/Data-structures.rmd
+++ b/Data-structures.rmd
@@ -142,7 +142,7 @@ names(mod)
 str(mod$qr)
 ```
 
-You can turn a list back into a vector using `unlist()`: this uses the same implicit coercion rules as for `c()`.
+You can turn a list back into an atomic vector using `unlist()`: this uses the same implicit coercion rules as for `c()`.
 
 ## Attributes
 


### PR DESCRIPTION
A list is defined as a vector in the text. Therefore, it would be more to correct to state, the the list can be transformed back into an "atomic" vector with unlist() ?
