### PR TITLE
clarify that run-all.R goes under R/tests, not inst/tests

### DIFF
--- a/Testing.rmd
+++ b/Testing.rmd
@@ -309,7 +309,7 @@ This promotes a workflow where the _only_ way you test your code is through test
 
 ## R CMD check
 
-When developing a package, put your tests in `inst/tests` (note that your test files must begin with `test`), and then create a file `tests/run-all.R` (note that it must be a capital R), which contains the following code:
+When developing a package, put your tests in `inst/tests` (note that your test files must begin with `test`), and then create a file `R/tests/run-all.R` (note that it must be a capital R), which contains the following code:
 
     library(testthat)
     library(mypackage)


### PR DESCRIPTION
When mentioned right after inst/tests, tests/run-all.R looks like inst/tests/run-all.R, at least to me when I'm learning this stuff. I tracked down [R CMD check docs](http://cran.r-project.org/doc/manuals/R-exts.html#Checking-packages) and realized my error. Being just a little more explicit might have helped me understand in the first place.
