### PR TITLE
Should be a hyperlink?

### DIFF
--- a/Subsetting.rmd
+++ b/Subsetting.rmd
@@ -536,7 +536,7 @@ Remember to use the vector boolean operators `&` and `|`, not the short-circuiti
 
 For example, `!(X & !(Y | Z))` simplifies to `!X | !!(Y|Z)`, and then to `!X | Y | Z`.
 
-`subset()` is a specialised shorthand function for subsetting data frames, and saves some typing because you don't need to repeat the name of the data frame. You'll learn how it works in [[Computing on the language]].
+`subset()` is a specialised shorthand function for subsetting data frames, and saves some typing because you don't need to repeat the name of the data frame. You'll learn how it works in [Computing on the language](Computing-on-the-language.html).
 
 ```{r}
 subset(mtcars, cyl == 4)


### PR DESCRIPTION
Attempted to correct the reference to include a hyperlink. Do not know if OK, as I do not know how to test it locally. In any case, the title of the referenced page is actually "Metaprogramming", so maybe the reference title should also be updated?
