### PR TITLE
Missing hyperlink

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -142,7 +142,7 @@ h()
 rm(x, h)
 ```
 
-The same rules apply to closures, functions created by other functions. Closures will be described in more detail in [[functional programming]]; here we'll just look at how they interact with scoping. The following function, `j()`, returns a function.  What do you think this function will return when we call it?
+The same rules apply to closures, functions created by other functions. Closures will be described in more detail in [functional programming(Functional-programming.html)]; here we'll just look at how they interact with scoping. The following function, `j()`, returns a function.  What do you think this function will return when we call it?
 
 ```{r, eval = FALSE}
 j <- function(x) {


### PR DESCRIPTION
Missing hyperlink to the chapter - this is not the only occurrence, there are more in this chapter alone.
