### PR TITLE
Missing hyperlink

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -307,7 +307,7 @@ x[3]
 `{`(print(1), print(2), print(3))
 ```
 
-It is possible to override the definitions of these special functions, but this is almost certainly a bad idea. However, it can occasionally allow you to do something that would have otherwise been impossible. For example, this feature makes it possible for the `dplyr` package to translate R expressions into SQL expressions. The [[dsl]] chapter discusses using this idea to create domain specific languages that allow you to concisely express new concepts using existing R constructs.
+It is possible to override the definitions of these special functions, but this is almost certainly a bad idea. However, it can occasionally allow you to do something that would have otherwise been impossible. For example, this feature makes it possible for the `dplyr` package to translate R expressions into SQL expressions. The [Domain specific languages(dsl.html)] chapter discusses using this idea to create domain specific languages that allow you to concisely express new concepts using existing R constructs.
 
 It's more often useful to treat special functions as ordinary functions. For example, we could use `sapply` to add 3 to every element of a list by first defining a function `add`, like this:
 


### PR DESCRIPTION
Missing hyperlink; name of chapter abbreviated and therefore not clear. (Will not report for further occurrences.)
