### PR TITLE
Change variable names to not conflict with data types or built-in functi...

### DIFF
--- a/Data-structures.rmd
+++ b/Data-structures.rmd
@@ -50,12 +50,12 @@ Each type of vector comes with an `as.*` coercion function and an `is.*` testing
 Atomic vectors can be logical, integer, double (often called numeric), or character, or less commonly complex or raw. Atomic vectors are usually created with `c()`, short for combine:
 
 ```{r}
-numeric <- c(1, 2.5, 4.5)
+a.numeric.variable <- c(1, 2.5, 4.5)
 # Note the L suffix distinguishes doubles from integers
-integer <- c(1L, 6L, 10L)
+an.integer.variable <- c(1L, 6L, 10L)
 # Use T and F or TRUE and FALSE to create logical vectors 
-logical <- c(T, FALSE, TRUE, FALSE)
-character <- c("these are", "some strings")
+a.logical.variable <- c(T, FALSE, TRUE, FALSE)
+a.character.variable <- c("these are", "some strings")
 ```
 
 Atomic vectors are flat, and nesting `c()` just creates a flat vector:
@@ -75,17 +75,17 @@ Given a vector, you can determine what type it is with `typeof()`, or with a spe
 NB: `is.numeric()` which is a general test for the "numberliness" of a vector, not a specific test for double vectors, which are often called numeric. It returns `TRUE` for integers:
 
 ```{r}
-integer <- c(1L, 6L, 10L)
-typeof(integer)
-is.integer(integer)
-is.double(integer)
-is.numeric(integer)
+an.integer.variable <- c(1L, 6L, 10L)
+typeof(an.integer.variable)
+is.integer(an.integer.variable)
+is.double(an.integer.variable)
+is.numeric(an.integer.variable)
 
-numeric <- c(1, 2.5, 4.5)
-typeof(numeric)
-is.integer(numeric)
-is.double(numeric)
-is.numeric(numeric)
+a.numeric.variable <- c(1, 2.5, 4.5)
+typeof(a.numeric.variable)
+is.integer(a.numeric.variable)
+is.double(a.numeric.variable)
+is.numeric(a.numeric.variable)
 ```
 
 #### Coercion
@@ -323,10 +323,10 @@ Beware that there are a few different ways to create a 1d datastructure: you can
 
 ```{r}
 str(list(
-  vector = 1:3,
+  a.vector.variable = 1:3,
   col_vector = matrix(1:3, ncol = 1),
   row_vector = matrix(1:3, nrow = 1),
-  array = array(1:3, 3)
+  an.array.variable = array(1:3, 3)
 ))
 ```
 


### PR DESCRIPTION
...ons

Using variable names that are the same as valid data types (numeric, e.g.) or the same as valid built-in functions (numeric, integer, vector, array, etc.) is confusing, could interfere with expected R operations, and is bad coding style.

"I assign the copyright of this contribution to Hadley Wickham".
