### PR TITLE
distinguish data.frame class from data.frame() function

### DIFF
--- a/Data-structures.rmd
+++ b/Data-structures.rmd
@@ -367,7 +367,7 @@ str(df)
 
 ### Testing and coercion
 
-Because data frame is an S3 class, it's type reflects the underlying vector used to build it: `list`. Instead you can look at its `class()` or test for a data frame with `is.data.frame()`:
+Because `data.frame` is an S3 class, it's type reflects the underlying vector used to build it: `list`. Instead you can look at its `class()` or test for a data frame with `is.data.frame()`:
 
 ```{r}
 typeof(df)
@@ -420,7 +420,7 @@ However, when a list is given to `data.frame()`, it tries to put each item of th
 data.frame(x = 1:3, y = list(1:2, 1:3, 1:4))
 ```
 
-A workaround is to use `I()` which causes `data.frame` to treat the list as one unit:
+A workaround is to use `I()` which causes `data.frame()` to treat the list as one unit:
 
 ```{r}
 dfl <- data.frame(x = 1:3, y = I(list(1:2, 1:3, 1:4)))


### PR DESCRIPTION
"data frame" isn't a class in S3, but `data.frame` is
