### PR TITLE
Incorrect link name?

### DIFF
--- a/Environments.rmd
+++ b/Environments.rmd
@@ -47,7 +47,7 @@ The job of an environment is to associate, or __bind__, a set of names to values
 
 Technically, an environment is made up of a __frame__, a collection of named objects (like a list), and a reference to a parent environment.  
 
-As well as powering scoping, environments can be also useful data structures because unlike almost every other type of object in R, modification takes place without a copy. This is not something that you should use without thought: it will violate users' expectations about how R code works, but it can sometimes be critical for high performance code.  However, since the addition of [[R5]], you're generally better off using reference classes instead of raw environments. Environments can also be used to simulate hashmaps common in other packages, because name lookup is implemented with a hash, which means that lookup is O(1). See the CRAN package hash for an example. 
+As well as powering scoping, environments can be also useful data structures because unlike almost every other type of object in R, modification takes place without a copy. This is not something that you should use without thought: it will violate users' expectations about how R code works, but it can sometimes be critical for high performance code.  However, since the addition of [RC](OO-essentials.html#rc), you're generally better off using reference classes instead of raw environments. Environments can also be used to simulate hashmaps common in other packages, because name lookup is implemented with a hash, which means that lookup is O(1). See the CRAN package hash for an example. 
 
 ### Manipulating and inspecting environments
 


### PR DESCRIPTION
It should say "RC" instead of "R5"? Anyway, the [[XYZ]] type of references are plentiful in the text and since I guess you'll do some regexp search for them, I will ignore them from now on.
