### PR TITLE
Replace separating-commas in simplifying/preserving table

### DIFF
--- a/Subsetting.rmd
+++ b/Subsetting.rmd
@@ -235,13 +235,13 @@ It's important to understand the distinction between simplifying and preserving 
 
 Unfortunately, how you switch between subsetting and preserving differs for different data types, as summarised in the table below.
 
-|             | Simplifying         | Preserving                 |
-|-------------|---------------------|----------------------------|
-| Vector      | `x[[1]]`           | `x[1]`                     | 
-| List        | `x[[1]]`           | `x[1]`                     | 
-| Factor      | `x[1:4, drop = T]`  | `x[1:4]`                   | 
-| Array       | `x[1, ]`, `x[, 1]`  | `x[1, , drop = F]`, `x[, 1, drop = F]` | 
-| Data frame  | `x[, 1]`, `x[[1]]`  | `x[, 1, drop = F]`, `x[1]` | 
+|             | Simplifying               | Preserving                                   |
+|-------------|---------------------------|----------------------------------------------|
+| Vector      | `x[[1]]`                  | `x[1]`                                       | 
+| List        | `x[[1]]`                  | `x[1]`                                       | 
+| Factor      | `x[1:4, drop = T]`        | `x[1:4]`                                     | 
+| Array       | `x[1, ]` __or__ `x[, 1]`  | `x[1, , drop = F]` __or__ `x[, 1, drop = F]` | 
+| Data frame  | `x[, 1]` __or__ `x[[1]]`  | `x[, 1, drop = F]` __or__ `x[1]`             | 
 
 Preserving is the same for all data types: you get the same type of output as input. Simplifying behaviour varies a little between different data types, as described below:
 


### PR DESCRIPTION
Use of commas to separate lists of subsetting examples which themselves have commas may be confusing for the reader.
