### PR TITLE
Correct typo

### DIFF
--- a/Subsetting.rmd
+++ b/Subsetting.rmd
@@ -560,7 +560,7 @@ It's useful to be aware of the natural equivalence between set operations (integ
 
 * You have very few `TRUE`s and very many `FALSE`s; a set representation may be faster and require less storage
 
-`which()` allows you to convert from a boolean representation to a integer representation. There's no reverse operation in base R, but we can easily add one:
+`which()` allows you to convert from a boolean representation to an integer representation. There's no reverse operation in base R, but we can easily add one:
 
 ```{r}
 x <- sample(10) < 4


### PR DESCRIPTION
a integer -> an integer
