### PR TITLE
few typos and edit package section to adapt to next Rcpp

### DIFF
--- a/Rcpp.rmd
+++ b/Rcpp.rmd
@@ -1019,6 +1019,30 @@ Rcpp.package.skeleton("NewPackage", example_code = FALSE,
                         cpp_files = c("convolve.cpp"))
 ```
 
+## Adding Rcpp to an existing package (Rcpp <= 0.10.6)
+
+To add `Rcpp` to an existing package, you put your C++ files in the `src/` directory and modify/create the following configuration files:
+
+* In `DESCRIPTION` add    
+
+        LinkingTo: Rcpp 
+
+  (If you're using advanced Rcpp features like modules, you'll also need `Imports: Rcpp and to import the specific functions you're using)
+
+* Make sure your `NAMESPACE` includes:
+
+        useDynLib(mypackage)
+
+* You need `src/Makevars` which contains:
+
+        PKG_LIBS = `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"`
+
+    And `src/Makevars.win` that contains:
+
+        PKG_LIBS = $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "Rcpp:::LdFlags()")
+
+## Adding Rcpp to an existing package (Rcpp >= 0.10.7)
+
 To add `Rcpp` to an existing package, you put your C++ files in the `src/` directory and modify/create the following configuration files:
 
 * In `DESCRIPTION` add    
@@ -1032,6 +1056,8 @@ To add `Rcpp` to an existing package, you put your C++ files in the `src/` direc
         importFrom( Rcpp, sourceCpp )
 
 We need to import something (anything) from Rcpp so that internal Rcpp code is properly loaded. In an ideal world, we would just need to use the `LinkingTo` but this is not enough. 
+
+## More details
 
 For more details see the [Writing a package that uses Rcpp vignette](http://cran.rstudio.com/web/packages/Rcpp/vignettes/Rcpp-package.pdf). 
 


### PR DESCRIPTION
I assign the copyright of this contribution to Hadley Wickham. 

About the XXX note, I've tried to implement match like this: 

``` cpp
// [[Rcpp::export]]
IntegerVector matchCpp( CharacterVector x, CharacterVector table){
  // first train an unordered_map
  std::unordered_map<String,int> map ;
  for( int i=0; i<table.size(); i++){
    String s = table[i] ;
    map[s] = i +1 ;
  }

  // now lookup
  int n = x.size() ;
  IntegerVector out(n) ;
  for( int i=0; i<n; i++){
    String s = x[i] ;
    out[i] = map[s]->second ;
  }
  return out ;
}
```

But the compiler complains about missing implementation of `std::hash<String>`. I've logged it as https://github.com/RcppCore/Rcpp/issues/84. 
