### PR TITLE
Added full stop (see also some comments).

### DIFF
--- a/Environments.rmd
+++ b/Environments.rmd
@@ -19,7 +19,7 @@ Understanding environment objects is an important next step of understanding sco
 
 The [[functions]] chapter focusses on the essence of how scoping works, where this chapter will focus more on the details and show you how you can implement the behaviour yourself. It also introduces some ideas that will be useful for [[computing on the language]].
 
-This chapter uses many functions found in the `pryr` package to pry open the covers of R and look inside the messy details.  Install `pryr` by running `devtools::install_github("pryr")`
+This chapter uses many functions found in the `pryr` package to pry open the covers of R and look inside the messy details.  Install `pryr` by running `devtools::install_github("pryr")`.
 
 ## Environment basics
 


### PR DESCRIPTION
1. The bullets under Introduction do not start with caps and finish with fuul stops. This could be on purpose or it could be an oversight and against the general form used in the book.
2. The instructions for installing pryr should come sooner in the text, as pryr is "used" in the previous chapters.
