### PR TITLE
distinguish between … and ….

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -571,9 +571,9 @@ You could write:
 
 ### `...`
 
-There is a special argument called `...`.  This argument will match any arguments not otherwise matched, and can be easily passed on to other functions.  This is useful if you want to collect arguments to call another function, but you don't want to prespecify their possible names. `...` is often used in conjunction with S3 generic functions to allow individual methods to be more flexible.
+There is a special argument called `...` .  This argument will match any arguments not otherwise matched, and can be easily passed on to other functions.  This is useful if you want to collect arguments to call another function, but you don't want to prespecify their possible names. `...` is often used in conjunction with S3 generic functions to allow individual methods to be more flexible.
 
-One relatively sophisticated user of `...` is the base `plot()` function. `plot()` is a generic method with arguments `x`, `y` and `...`. To understand what `...` does for a given function we need to read the help: "Arguments to be passed to methods, such as graphical parameters". Most simple invocation of `plot()` ends up calling `plot.default()` which has many more arguments, but also has `...`.  Again, reading the documentation reveals that `...` accepts "other graphical parameters", which are listed the help for `par()`.  This allows us to write code like:
+One relatively sophisticated user of `...` is the base `plot()` function. `plot()` is a generic method with arguments `x`, `y` and `...` . To understand what `...` does for a given function we need to read the help: "Arguments to be passed to methods, such as graphical parameters". Most simple invocation of `plot()` ends up calling `plot.default()` which has many more arguments, but also has `...` .  Again, reading the documentation reveals that `...` accepts "other graphical parameters", which are listed the help for `par()`.  This allows us to write code like:
 
 ```{r, eval = FALSE}
 plot(1:5, col = "red")


### PR DESCRIPTION
`...` followed by a full stop looks like four dots. I've suggested inserting a space (in three places), but a better solution would be to reword avoiding ending the sentence with `...`.
