### PR TITLE
Update Package-quick-reference.rmd

### DIFF
--- a/Package-quick-reference.rmd
+++ b/Package-quick-reference.rmd
@@ -13,7 +13,7 @@ All devtools package functions take a package path as the first argument. If it 
 
 * With no R files: `create("mypackage")`
 
-* With R files: copy in to a directory called `R/` and then run `load_all()`
+* With R files: copy in to a directory which contains a DESCRIPTION file and a directory called `R/` and then run `load_all()`
 
 ## Development workflow
 


### PR DESCRIPTION
When I setwd() to the R directory I got this error message:

> load_all();
> No DESCRIPTION found. Creating with values:

Package: R
Title: 
Description: 
Version: 0.1
Authors@R: # getOptions('devtools.desc.author')
Depends: R (>= 3.0.2)
License: # getOptions('devtools.desc.license')
LazyData: true
Loading R
Invalid DESCRIPTION:
Authors@R field gives no person with author role.
Authors@R field gives no person with maintainer role and email address.

See the information on DESCRIPTION files in section 'Creating R packages' of the 'Writing R Extensions' manual.

Then when I moved up a directory (to the directory that has the DESCRIPTION file) it worked:

> setwd("..")
> load_all();
> Loading choroplethr
