### PR TITLE
Update Functionals.rmd

### DIFF
--- a/Functionals.rmd
+++ b/Functionals.rmd
@@ -842,7 +842,7 @@ lbapply(x, f, alpha = 0.5)
 
 This is only worthwhile if we need this function frequently: otherwise it just places an additional cognitive burden on the reader.
 
-Another solution for eliminate the for loop in these cases is to [solve the recurrence relation](http://en.wikipedia.org/wiki/Recurrence_relation#Solving), removing the recursion and replacing it explicit references. This requires a new set of tools, and is mathematically challenging, but it can pay off by producing a simpler function. For exponential smoothing, it is possible to rewrite in terms of `i`:
+Another solution for eliminate the for loop in these cases is to [solve the recurrence relation](http://en.wikipedia.org/wiki/Recurrence_relation#Solving), removing the recursion and replacing it with explicit references. This requires a new set of tools, and is mathematically challenging, but it can pay off by producing a simpler function. For exponential smoothing, it is possible to rewrite in terms of `i`:
 
 ```{r}
 exps1 <- function(x, alpha) {


### PR DESCRIPTION
added redundant word to make sentence more clear:
the first _argument_ to most functionals is ... but the first argument to 'Map()' is...
changed order of arguments in "where" definition to match syntax of other predicate functionals.
changed predicate functional demo code example function to "is.factor" to make example more clear.
