### PR TITLE
Minor typo suggestion

### DIFF
--- a/Computing-on-the-language.rmd
+++ b/Computing-on-the-language.rmd
@@ -428,10 +428,11 @@ Again, we can turn to substitute and use it for another purpose:  modifying expr
 
 Unfortunately `substitute()` has a "feature" that makes experimenting with it interactively a bit of a pain: it never does substitutions when run from the global environment, and just behaves like `quote()`:
 
-```{r}
+```{r, eval = FALSE}
 a <- 1
 b <- 2
 substitute(a + b + x)
+#> a + b + x
 ```
 
 But if we run it inside a function, `substitute()` substitutes what it can and leaves everything else the same:
@@ -443,8 +444,6 @@ f <- function() {
   substitute(a + b + x)
 }
 f()
-# I think there may be a quirk in how knitr converts .Rmd to .md that provides "incorrect" output here
-# On rendered website, the output to the above code chunk is "#> 1 + 2 + mpg", when it should be "#> a + b + x"
 ```
 
 To make it easier to experiment with `substitute()`, `pryr` provides the `subs()` function.  It works exactly the same way as `substitute()` except it has a shorter name and if the second argument is the global environment it turns it into a list. Together, this makes it much easier to experiment with substitution:


### PR DESCRIPTION
On the rendered website, the console output for a code chunk (lines 439-445) should be
# > a + b + x

But is instead
# > 1 + 2 + mpg

I am not sure how to fix this, but wanted to point it out. Appears to be a quirk in how knitr converts .Rmd to .md, but I do not know enough about knitr internals to know for sure.

I assign the copyright of this contribution to Hadley Wickham.
