### PR TITLE
Typo corrections

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -34,13 +34,17 @@ There are three properties that all R functions possess:
 
 When you print a function in R, it shows you these three important components. If the environment isn't displayed, it means that the function was created in the global environment. 
 
-```{r}
+```{r, eval = FALSE}
 f <- function(x) x
 f
+#> function(x) x
 
 formals(f)
+#> $x
 body(f)
+#> x
 environment(f)
+#> <environment: R_GlobalEnv>
 ```
 
 The assignment forms of `body()`, `formals()`, and `environment()` can also be used to modify functions. This is a useful technique which we'll explore in more detail in [computing on the language](Computing-on-the-language.html).
@@ -514,9 +518,7 @@ f(ls())
 
 More technically, an unevaluated argument is called a __promise__, or (less commonly) a thunk. A promise is made up of two parts:
 
-* an expression giving the delayed computation, which can be accessed with
-* `substitute` (see [controlling
-* evaluation](Computing-on-the-language.html#Non-standard-evaluation-in-subset) for more details)
+* an expression giving the delayed computation, which can be accessed with `substitute` (see [controlling evaluation](Computing-on-the-language.html#Non-standard-evaluation-in-subset) for more details)
 
 * the environment where the expression was created and where it should be evaluated
 


### PR DESCRIPTION
Two changes:
- Set code chunk lines 37-43 to be {r, eval = FALSE}, as it was not giving desired output (was showing <environment: 0x1034b2268> after calling both f and environment(f), when it should've been suppressed and showing <environment: R_GlobalEnv>, respectively). Manually inserted comments with desired output.
- Removed two extra bullet points (just the bullets not the content) from lines 517-519 as a minor formatting fix.

I assign the copyright of this contribution to Hadley Wickham.
