### PR TITLE
typo - "reason" to "reasons"

### DIFF
--- a/Data-structures.rmd
+++ b/Data-structures.rmd
@@ -43,7 +43,7 @@ Take this short quiz to determine if you need to read this chapter. If the answe
 
 The basic data structure in R is the vector, which comes in two basic flavours: atomic vectors and lists. They differ in their content: the contents of an atomic vector must all be the same type, the contents of a list can have different types. Atomic is so named because it forms the "atoms" of R's data structures. As well as their content, vectors have three properties: `typeof()` (what it is), `length()` (how long it is) and `attributes()` (additional arbitrary metadata). The most common attribute is `names()`.
 
-Each type of vector comes with an `as.*` coercion function and an `is.*` testing function. But beware. For historical reason, `is.vector()` returns `TRUE` only if the object is a vector with no attributes apart from names. Use `is.atomic(x) || is.list(x)` to test if an object is actually a vector.
+Each type of vector comes with an `as.*` coercion function and an `is.*` testing function. But beware. For historical reasons, `is.vector()` returns `TRUE` only if the object is a vector with no attributes apart from names. Use `is.atomic(x) || is.list(x)` to test if an object is actually a vector.
 
 ### Atomic vectors
 


### PR DESCRIPTION
"For historical reason" to "For historical reasons"

"For a historical reason" could also be correct, but the proposed fix is typical, in American English anyway.
