### PR TITLE
don't show answers for exercises

### DIFF
--- a/Data-structures.rmd
+++ b/Data-structures.rmd
@@ -162,7 +162,7 @@ Using the same implicit coercion rules as for `c()`, you can turn a list back in
 3. Test your knowledge of vector coercion rules by predicting the output of
    the following uses of `c()`:
    
-    ```{r}
+    ```{r, eval=FALSE}
     c(1, F)
     c("a", 1)
     c(list(1), "a")


### PR DESCRIPTION
Other exercises don't have answers, so it would probably be best to follow that convention here as well.
