### PR TITLE
correct arg to read.csv is na.strings

### DIFF
--- a/Data-structures.rmd
+++ b/Data-structures.rmd
@@ -258,7 +258,7 @@ table(sex_char)
 table(sex_factor)
 ```
 
-Someimes when a data frame is read directly from a file, a column you had thought would produce a numeric vector instead produces a factor, with the numbers appearing in the levels. This is caused by a non-numeric value in the column, often a missing value encoded in a special way like `.` or `-`. To remedy the situation you will need to coerce the vector from a factor to character, and then from character to numeric. (Be sure to check for missing values after this process.) Of course, a much better plan is to discover and fix what caused the problem in the first place; using using the `na.value` argument to `read.csv()` is often a good place to start.
+Someimes when a data frame is read directly from a file, a column you had thought would produce a numeric vector instead produces a factor, with the numbers appearing in the levels. This is caused by a non-numeric value in the column, often a missing value encoded in a special way like `.` or `-`. To remedy the situation you will need to coerce the vector from a factor to character, and then from character to numeric. (Be sure to check for missing values after this process.) Of course, a much better plan is to discover and fix what caused the problem in the first place; using using the `na.strings` argument to `read.csv()` is often a good place to start.
 
 ```{r}
 z <- factor(c(12, 1, 9))


### PR DESCRIPTION
From the help for read.csv:
na.strings
a character vector of strings which are to be interpreted as NA values. Blank fields are also considered to be missing values in logical, integer, numeric and complex fields.
