### PR TITLE
likely typo - "simple" to "single"

### DIFF
--- a/Subsetting.rmd
+++ b/Subsetting.rmd
@@ -161,7 +161,7 @@ df[c("x", "z")]
 # Like a matrix
 df[, c("x", "z")]
 
-# There's an important difference if you select a simple column:
+# There's an important difference if you select a single column:
 # matrix subsetting simplifies by default, list subsetting does not.
 str(df["x"])
 str(df[, "x"])


### PR DESCRIPTION
not clear what a "simple column" would be; I think it should be "single column" here, yes?
