### PR TITLE
typo - "NA_real" to "NA_real_"

### DIFF
--- a/Subsetting.rmd
+++ b/Subsetting.rmd
@@ -325,14 +325,14 @@ str(x[NULL])
 
 The following table summarises the results of subsetting atomic vectors and lists with `[` and `[[` and different types of OOB value. 
 
-| Operator | Index      | Atomic      | List          |
-|----------|------------|-------------|---------------|
-| `[`      | OOB        | `NA`        | `list(NULL)`  |
-| `[`      | `NA_real_` | `NA`        | `list(NULL)`  |
-| `[`      | `NULL`     | `x[0]`      | `list(NULL)`  |
-| `[[`     | OOB        | Error       | Error         |
-| `[[`     | `NA_real`  | Error       | `NULL`        |
-| `[[`     | `NULL`     | Error       | Error         |
+| Operator | Index       | Atomic      | List          |
+|----------|-------------|-------------|---------------|
+| `[`      | OOB         | `NA`        | `list(NULL)`  |
+| `[`      | `NA_real_`  | `NA`        | `list(NULL)`  |
+| `[`      | `NULL`      | `x[0]`      | `list(NULL)`  |
+| `[[`     | OOB         | Error       | Error         |
+| `[[`     | `NA_real_`  | Error       | `NULL`        |
+| `[[`     | `NULL`      | Error       | Error         |
 
 If the input vector is named, then the names of OOB, missing, or `NULL` components will be `"<NA>"`.
 


### PR DESCRIPTION
> NA_real
> Error: object 'NA_real' not found
