### PR TITLE
force the error message to show

### DIFF
--- a/Exceptions-Debugging.rmd
+++ b/Exceptions-Debugging.rmd
@@ -362,7 +362,7 @@ f1("x")
 
 However, if you wrap the statement that creates the error in `try()`, the error message will be printed but execution will continue:
 
-```{r}
+```{r, error = TRUE}
 f2 <- function(x) {
   try(log(x))
   10


### PR DESCRIPTION
I am guessing that the error message is supposed to show here as you say "the error message will be printed but execution will..."
