### PR TITLE
typos - "mostly" to "most" and punctuation

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -362,7 +362,7 @@ str(f(2, 3, a = 1))
 str(f(1, 3, b = 1))
 ```
 
-Generally, you only want to use positional matching for the first one or two arguments: they will be the mostly commonly used, and most readers will know what they are. Avoid using positional matching for less commonly used arguments, and only use readable abbreviations with partial matching. (If you are writing code for a package that you want to publish on CRAN you can not use partial matching, and must use complete names.) Named arguments should always come after unnamed arguments. If a function uses `...` (discussed in more detail below), you can only specify arguments listed after `...` with their full name.
+Generally, you only want to use positional matching for the first one or two arguments; they will be the most commonly used, and most readers will know what they are. Avoid using positional matching for less commonly used arguments, and only use readable abbreviations with partial matching. (If you are writing code for a package that you want to publish on CRAN you can not use partial matching, and must use complete names.) Named arguments should always come after unnamed arguments. If a function uses `...` (discussed in more detail below), you can only specify arguments listed after `...` with their full name.
 
 These are good calls:
 


### PR DESCRIPTION
I think the semicolon is more appropriate here, but it might be arguable.
