### PR TITLE
typo / clarification - parenthesis and quotations

### DIFF
--- a/OO-essentials.rmd
+++ b/OO-essentials.rmd
@@ -180,7 +180,7 @@ As you can see, there's no check to make sure that the method returns a class co
 
 ### Method dispatch
 
-S3 method dispatch is relatively simple. `UseMethod()` creates a vector of function names, like `paste0(generic, ".", c(class(x), "default")` and looks for each in turn. The "default" class makes it possible to set up a fall back method for otherwise unknown classes.
+S3 method dispatch is relatively simple. `UseMethod()` creates a vector of function names, like `paste0("generic", ".", c(class(x), "default"))` and looks for each in turn. The "default" class makes it possible to set up a fall back method for otherwise unknown classes.
 
 ```{r}
 f <- function(x) UseMethod("f")


### PR DESCRIPTION
the extra paren is needed (syntax)
and the quotes around "generic" are probably good - you couldn't before just stick "mean" in there without quotes and have it work as expected
