### PR TITLE
messy outputs on webpage

### DIFF
--- a/Functionals.rmd
+++ b/Functionals.rmd
@@ -356,7 +356,7 @@ In brief, `mapply()` is more complicated for little gain.
 
 What if you need a for-loop replacement that doesn't exist in base R? You can often create your own by recognising common looping structures and implementing your own wrapper. For example, you might be interested in smoothing your data using a rolling (or running) mean function:
 
-```{r roll-mean}
+```{r}
 rollmean <- function(x, n) {
   out <- rep(NA, length(x))
 
@@ -374,7 +374,7 @@ lines(rollmean(x, 10), col = "red", lwd = 2)
 
 But if the noise was more variable (i.e. it had a longer tail) you might worry that your rolling mean was too sensitive to the occasional outlier and instead implement a rolling median. 
 
-```{r outliers, fig.caption = "Rolling means with heavy-tailed distribution."}
+```{r, fig.caption = "Rolling means with heavy-tailed distribution."}
 x <- seq(1, 3, length = 1e2) + rt(1e2, df = 2) / 3
 plot(x)
 lines(rollmean(x, 5), col = "red", lwd = 2)
@@ -382,7 +382,7 @@ lines(rollmean(x, 5), col = "red", lwd = 2)
 
 To modify `rollmean()` to `rollmedian()` all you need to do is replace `mean` with `median` inside the loop, but instead of copying and pasting to create a new function, we could extract the idea of computing a rolling summary into its own function:
 
-```{r roll-apply}
+```{r}
 rollapply <- function(x, n, f, ...) {
   out <- rep(NA, length(x))
 
@@ -398,7 +398,7 @@ lines(rollapply(x, 5, median), col = "red", lwd = 2)
 
 You might notice that the internal loop looks pretty similar to a `vapply()` loop, so we could rewrite the function as:
 
-```{r roll-apply-2}
+```{r}
 rollapply <- function(x, n, f, ...) {
   offset <- trunc(n / 2)
   locs <- (offset + 1):(length(x) - n + offset - 1)


### PR DESCRIPTION
On the webpage, these code chunks output appear to be messy on my laptop browser. Checked on two laptops in Chrome and Safari. Compared to other ones that show correctly, I guess (not so sure) it is the knitr code chunk names that are causing the issue.
