### PR TITLE
align code to framing text

### DIFF
--- a/Environments.rmd
+++ b/Environments.rmd
@@ -344,7 +344,7 @@ This mechanism makes it possible for packages to have internal objects that can 
 
 Recall how function scoping works. What will the following function return the first time we run it? What about the second?
 
-```{r}
+```{r, eval = FALSE}
 f <- function(x) {
   if (!exists("a", inherits = FALSE)) {
     message("Defining a")
@@ -354,7 +354,6 @@ f <- function(x) {
   }
   a
 }
-f()
 ```
 
 In fact, it will return the same value each and every time it is called. This is because each time a function is called, a new environment is created to host execution. We can see this more easily by returning the environment inside a function (use `environment()` with no arguments and try running it at the top level). That said, note that all those newly created environments have the same parent environment: the environment where the function was created:


### PR DESCRIPTION
The text asks the reader to think about this for a first and second execution, so probably we don't want to a) call the function once and b) show the output.

As a note, this is almost identical to the example in the section "A fresh start" in "Functions". This is probably fine, but for some readers going straight through the duplication could be a little irksome.
