### PR TITLE
grammar and argument fix

### DIFF
--- a/Environments.rmd
+++ b/Environments.rmd
@@ -519,9 +519,9 @@ The remainder of this section will discuss the four main ways of binding names t
 
 * The double arrow, `name <<- value`, assigns in a similar way to variable lookup, so that `i <<- i + 1` modifies the binding of the original `i`, which is not necessarily in the current environment.
 
-* Lazy assignment, `delayedAssign("name", expression)`, binds an expression isn't evaluated until you look up the name.
+* Lazy assignment, `delayedAssign("name", expression)`, binds an expression that isn't evaluated until you look up the name.
 
-* Active assignment, `makeActiveBinding("name", function)` binds the name to a function, so it is "active" and can return different a value each time the name is found.
+* Active assignment, `makeActiveBinding("name", function, environment)` binds the name to a function, so it is "active" and can return a different value each time the name is found.
 
 ### Regular binding
 


### PR DESCRIPTION
add "that", "a"

makeActiveBinding doesn't have a default for the env arg, so including something for it in the call
