### PR TITLE
simplify (fix?) code

### DIFF
--- a/Environments.rmd
+++ b/Environments.rmd
@@ -580,7 +580,7 @@ There's one extension to regular binding: constants. What are constants? They're
 
 ```{r, error = TRUE}
 x <- 10
-lockBinding(as.name("x"), globalenv())
+lockBinding("x", globalenv())
 x <- 15
 rm(x)
 


### PR DESCRIPTION
Right now the rendered version looks like this:

"""
x <- 10
lockBinding(as.name("x"), globalenv())
# > Error: no binding for "x"

x <- 15
rm(x)
"""

I'm not sure why this is. On my machine at least, it seems that "as.name()" is not necessary for this snippet to work - but I also can't replicate the "no binding" error. I defer to your judgement if this change is not good.
