### PR TITLE
"highest" instead of "lowest"

### DIFF
--- a/Environments.rmd
+++ b/Environments.rmd
@@ -668,7 +668,7 @@ b %<d-% {Sys.sleep(1); 1}
 system.time(b)
 ```
 
-Note that we need to be careful with more complicated expressions because user created infix functions have the lowest possible precedence: `x %<d-% a + b` is interpreted as `(x %<d-% a) + b`, so we need to use parentheses ourselves:
+Note that we need to be careful with more complicated expressions because user created infix functions have the highest possible precedence: `x %<d-% a + b` is interpreted as `(x %<d-% a) + b`, so we need to use parentheses ourselves:
 
 ```{r}
 x %<d-% (a + b)


### PR DESCRIPTION
To me it seems like the precedence is high if they go first; is this not correct?
