### PR TITLE
dummy out block to include error

### DIFF
--- a/Exceptions-Debugging.rmd
+++ b/Exceptions-Debugging.rmd
@@ -362,12 +362,14 @@ f1("x")
 
 However, if you wrap the statement that creates the error in `try()`, the error message will be printed but execution will continue:
 
-```{r, error = TRUE}
+```{r, eval = FALSE, tidy = FALSE}
 f2 <- function(x) {
   try(log(x))
   10
 }
 f2()
+#> Error in log(x) : non-numeric argument to mathematical function
+#> [1] 10
 ```
 
 You can suppress the message with `try(..., silent = TRUE)`. 


### PR DESCRIPTION
knitr doesn't show the error for this block, even with error=TRUE, which is bad because the point of the block is to show the error. I'm not sure why knitr doesn't show this error; this is the quick hack solution to just fake the block so that it looks the way it does when trying it at the console.
