### PR TITLE
Changing class manually with short output

### DIFF
--- a/OO-essentials.rmd
+++ b/OO-essentials.rmd
@@ -142,11 +142,14 @@ Apart from developer supplied constructor functions, S3 has no checks for correc
 # Create a linear model
 mod <- lm(log(mpg) ~ log(disp), data = mtcars)
 class(mod)
+print(mod)
 
-# Turn it into a table (?!)
-class(mod) <- "table"
+# Turn it into a data frame (?!)
+class(mod) <- "data.frame"
 # But unsurprisingly this doesn't work very well
 print(mod)
+# However, the data is still there
+mod$coefficients
 ```
 
 If you've used other OO languages, this might make you feel queasy. But surprisingly, this flexibility causes few problems: while you _can_ change the type of an object, you never should. R doesn't protect you from yourself: you can easily shoot yourself in the foot. As long as you don't aim the gun at your foot and pull the trigger, you won't have a problem.


### PR DESCRIPTION
1. adding print(mod) before changing class to show what is expected by default
2. replacing "table" by "data.frame", since printing as table gives a really really long output
3. additionally showing that the data itself is intact

I assign the copyright of this, all past and future contributions to Hadley Wickham
