### PR TITLE
Update Package-development-cycle.rmd (typos/suggestions)

### DIFF
--- a/Package-development-cycle.rmd
+++ b/Package-development-cycle.rmd
@@ -5,7 +5,7 @@ layout: default
 
 # The package development cycle
 
-The package development cycle describes the sequence of operations that you use when developing a package. You probably already have a sequence of operations that you're already comfortable with when developing a single file of R code. It might be:
+The package development cycle describes the sequence of operations that you use when developing a package. You probably already have a sequence of operations that you're comfortable with when developing a single file of R code. It might be:
 
 * Try something out on the command line.
 
@@ -58,7 +58,7 @@ The three functions that you'll use most often are:
 
 This makes the development process very easy. After you've modified the code, you run `load_all("pkg")` to load it in to R. You can explore it interactively from the command line, or type `test("pkg")` to run all your automated tests.
 
-Some GUIs have integrated supported for these functions. Rstudio provides the build menu, which allows you to easily run `load_all` with a single key press (Ctrl + Shift + L at time of writing). ESS? 
+Some GUIs have integrated support for these functions. RStudio provides the build menu, which allows you to easily run `load_all` with a single key press (Ctrl + Shift + L at time of writing). ESS? 
 
 The following sections describe how you might combine these functions into a process.
 
@@ -68,7 +68,7 @@ It's useful to distinguish between exploratory programming and confirmatory prog
 
 ### Confirmatory programming
 
-Confirmatory programming happens when you know what you need to do and what the results of your changes will be (new feature X appears or known bug Y disappears); you just need to figure out the way to do it. Confirmatory programming is also known as [test driven development][tdd] (TDD), a development style that grew out of extreme programming. The basic idea is that, before you implement any new feature or fix a known bug, you should:
+Confirmatory programming happens when you know what you need to do and what the results of your changes will be (new feature X appears or known bug Y disappears); you just need to figure out the way to do it. Confirmatory programming is also known as [test driven development][tdd] (TDD), a development style that grew out of [extreme programming](extreme-programming). The basic idea is that, before you implement any new feature or fix a known bug, you should:
 
 1. Write an automated test and run `test()` to make sure the test fails (so you know
    you've captured the bug correctly).
@@ -77,7 +77,7 @@ Confirmatory programming happens when you know what you need to do and what the 
 
 3. Run `test(pkg)` to reload the package and re-run the tests.
 
-4. Repeat 2--4 until all tests pass.
+4. Repeat 2--3 until all tests pass.
 
 5. Update documentation comments, run `document()`, and update `NEWS`.
 
@@ -103,4 +103,5 @@ The automated tests are still vitally important because they are what will preve
 
 [devtools-down]:https://github.com/hadley/devtools/tarball/master
 [tdd]:http://en.wikipedia.org/wiki/Test-driven_development
+[extreme-programming]:http://en.wikipedia.org/wiki/Extreme_programming
 


### PR DESCRIPTION
- Removed extra "already" from line 8.
- Changed "supported" to "support" on line 61
- Changed "Rstudio" to "RStudio" on line 61, to be consistent with how it is styled on RStudio.com =)
- Also on line 61: confirmed `ctrl + shift + L` is still correct for RStudio. Also appears that as of [ESS 13.09](http://ess.r-project.org/Manual/ess.html), `C-c C-t l` in ESS will run `load_all`. I did not add the ESS change in the source, since you have "ESS?" written there. Just wanted to point this out in case you did want to add it.
- Changed "Repeat 2--4" to "Repeat 2--3" on line 80, in order to be consistent with the instruction style of line 96.
- Added a Wikipedia link for "extreme programming". Even though it is linked in the test-driven development Wikipedia entry, I thought it might be useful and more direct for readers. Lines 71 and 106.
