### PR TITLE
Fix typo

### DIFF
--- a/Computing-on-the-language.rmd
+++ b/Computing-on-the-language.rmd
@@ -457,7 +457,7 @@ library(pryr)
 subs(a + b + x)
 ```
 
-The second argument (to both `sub()` and `substitute()`) can override the use of the current environment, and provide an alternative list of name-value pairs to use. The following example uses that technique to show some variations on substituting a string, variable name or function call:
+The second argument (to both `subs()` and `substitute()`) can override the use of the current environment, and provide an alternative list of name-value pairs to use. The following example uses that technique to show some variations on substituting a string, variable name or function call:
 
 ```{r}
 subs(a + b, list(a = "y"))


### PR DESCRIPTION
Fixing typo on line 460: sub() -> subs()
