### PR TITLE
clarify two example implementations

### DIFF
--- a/Functionals.rmd
+++ b/Functionals.rmd
@@ -983,21 +983,25 @@ r_add(numeric())
 
 (This is equivalent to `sum()`.)
 
-It would also be nice to have a vectorised version of `add` so that we can give it two vectors of numbers to add in parallel. We have two ways, using `Map()` or `vapply()`, to implement this, neither of which are perfect. `Map()` returns a list (we want a numeric vector), and while `vapply()` returns a vector, we'll need to loop over the indices.
+It would also be nice to have a vectorised version of `add` so that we can give it two vectors of numbers to add together element-wise. We could use `Map()` or `vapply()` to implement this. Neither method is perfect. `Map()` returns a list (we want a numeric vector), and while `vapply()` returns a vector, we'll need to loop over the indices.
 
-A few test cases makes sure that it behaves as we expect.  We're a bit stricter than base R here because we don't do recycling - you could add that if you wanted, but I find problems with recycling a common source of silent bugs.
+A few test cases makes sure that it behaves as we expect.  We're a bit stricter than base R here because we don't do recycling - you could add that if you wanted, but I find that problems with recycling are a common source of silent bugs.
 
 ```{r}
-v_add <- function(x, y, na.rm = TRUE) {
-  stopifnot(length(x) == length(y), is.numeric(x), is.numeric(y))
-  Map(function(x, y) add(x, y, na.rm = na.rm), x, y)
-}
+# An implementation with `Map()`
+# v_add <- function(x, y, na.rm = TRUE) {
+#   stopifnot(length(x) == length(y), is.numeric(x), is.numeric(y))
+#   Map(function(x, y) add(x, y, na.rm = na.rm), x, y)
+# }
 
+# An implementation with `vapply()`
 v_add <- function(x, y, na.rm = TRUE) {
   stopifnot(length(x) == length(y), is.numeric(x), is.numeric(y))
   vapply(seq_along(x), function(i) add(x[i], y[i], na.rm = na.rm),
     numeric(1))
 }
+
+# Test cases
 v_add(1:10, 1:10)
 v_add(numeric(), numeric())
 v_add(c(1, NA), c(1, NA))


### PR DESCRIPTION
Computation is vectorized but not really happening in parallel (in the mclapply sense) so calling it "element-wise"; also avoiding the declaration and immediate re-declaration of the function by commenting out and labeling with comments.
