### PR TITLE
re-clarify two examples

### DIFF
--- a/Functionals.rmd
+++ b/Functionals.rmd
@@ -983,28 +983,31 @@ r_add(numeric())
 
 (This is equivalent to `sum()`.)
 
-It would also be nice to have a vectorised version of `add` so that we can give it two vectors of numbers to add in parallel. We have two ways, using `Map()` or `vapply()`, to implement this, neither of which are perfect. `Map()` returns a list (we want a numeric vector), and while `vapply()` returns a vector, we'll need to loop over the indices.
+It would also be nice to have a vectorised version of `add` so that we can give it two vectors of numbers to add together element-wise. We could use `Map()` or `vapply()` to implement this. Neither method is perfect. `Map()` returns a list (we want a numeric vector), and while `vapply()` returns a vector, we'll need to loop over the indices.
 
-A few test cases makes sure that it behaves as we expect.  We're a bit stricter than base R here because we don't do recycling - you could add that if you wanted, but I find problems with recycling a common source of silent bugs.
+A few test cases makes sure that it behaves as we expect.  We're a bit stricter than base R here because we don't do recycling - you could add that if you wanted, but I find that problems with recycling are a common source of silent bugs.
 
 ```{r}
-v_add <- function(x, y, na.rm = TRUE) {
+v_add1 <- function(x, y, na.rm = FALSE) {
   stopifnot(length(x) == length(y), is.numeric(x), is.numeric(y))
-  Map(function(x, y) add(x, y, na.rm = na.rm), x, y)
+  if (length(x) == 0) return(numeric())
+  simplify2array(Map(function(x, y) add(x, y, na.rm = na.rm), x, y))
 }
 
-v_add <- function(x, y, na.rm = TRUE) {
+v_add2 <- function(x, y, na.rm = FALSE) {
   stopifnot(length(x) == length(y), is.numeric(x), is.numeric(y))
   vapply(seq_along(x), function(i) add(x[i], y[i], na.rm = na.rm),
     numeric(1))
 }
-v_add(1:10, 1:10)
-v_add(numeric(), numeric())
-v_add(c(1, NA), c(1, NA))
-v_add(c(1, NA), c(1, NA), na.rm = TRUE)
+
+# Both versions will achieve the same results
+v_add1(1:10, 1:10)
+v_add2(numeric(), numeric())
+v_add1(c(1, NA), c(1, NA))
+v_add2(c(1, NA), c(1, NA), na.rm = TRUE)
 ```
 
-(This is the usual behavior of `+` in R, although we have more control over missing values.)
+(This is the usual behavior of `+` in R, but we have more control over missing values.)
 
 Another variant of adding is the cumulative sum: it's like the reductive version, but we see every step along the way to the final result. This is easy to implement with `Reduce()`'s `accumulate` argument:
 


### PR DESCRIPTION
(updates https://github.com/hadley/adv-r/pull/412)

I had to add a special case because `simplify2array` doesn't like zero-length input. (`unlist` returns `NULL`, which is trash as well.)

Also realized that na.rm was defaulted to TRUE, so changed that.
