### PR TITLE
Fix the way of getting Rinternals header path

### DIFF
--- a/C-interface.rmd
+++ b/C-interface.rmd
@@ -88,7 +88,7 @@ add(1, 5)
 The C functions and macros that R provides for us to modify R data structures are all defined in the header file `Rinternals.h`.  It's easiest to find and display this file from within R:
 
 ```{r, eval = FALSE}
-rinternals <- file.path(R.home(), "include", "Rinternals.h")
+rinternals <- file.path(R.home("include"), "Rinternals.h")
 file.show(rinternals)
 ```
 


### PR DESCRIPTION
`file.path(R.home(), "include", "Rinternals.h")` may lead to wrong paths such as `/usr/lib/R/include/Rinternals.h` on some distributions like Ubuntu. 

`file.path(R.home("include"), "Rinternals.h")`

seems to be a better way, which also takes `R_INCLUDE_DIR` env. variable into account.
