### PR TITLE
Update Subsetting - minor tweaks

### DIFF
--- a/Subsetting.rmd
+++ b/Subsetting.rmd
@@ -231,7 +231,7 @@ S3 and S4 objects can override the standard behaviour of `[` and `[[` so they be
 
 ### Simplifying vs. preserving subsetting {#simplify-preserve}
 
-It's important to understand the distinction between simplifying and preserving subsetting. Simplifying subsets return the simplest possible data structure that can represent the output. They are useful interactively because they usually give you what you want. Preserving subsetting keeps the structure of the output the same as the input. It is generally better for programming because the result will always be the same type. Omitting `drop = FALSE` when subsetting matrices and data frames is one of the most common sources of programming errors. (It'll work for your test cases, but then someone will pass in a single column data frame and it will fail in an unexpected and unclear way).
+It's important to understand the distinction between simplifying and preserving subsetting. Simplifying subsets returns the simplest possible data structure that can represent the output, and is useful interactively because it usually gives you what you want. Preserving subsetting keeps the structure of the output the same as the input, and is generally better for programming because the result will always be the same type. Omitting `drop = FALSE` when subsetting matrices and data frames is one of the most common sources of programming errors. (It will work for your test cases, but then someone will pass in a single column data frame and it will fail in an unexpected and unclear way).
 
 Unfortunately, how you switch between subsetting and preserving differs for different data types, as summarised in the table below.
 


### PR DESCRIPTION
Minor tweaks:
- fixed some grammar
- changed sentence structure to remove the use of "they" and "it" when it was unclear what those words were referring to
