### PR TITLE
typo

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -49,7 +49,7 @@ environment(f)
 
 The assignment forms of `body()`, `formals()`, and `environment()` can also be used to modify functions. This is a useful technique which we'll explore in more detail in [metaprogramming](#metaprogramming).
 
-Like all objects in R, functions can also possess any number of additional `attributes()`. One attribute used by base R is "srcref", short for source reference, which points to the source code used to create the function. Unlike `body()`, this contains code comments and other formatting. You can also add attributes to a function. For example, you can can set the `class()` and add a custom `print()` method.
+Like all objects in R, functions can also possess any number of additional `attributes()`. One attribute used by base R is "srcref", short for source reference, which points to the source code used to create the function. Unlike `body()`, this contains code comments and other formatting. You can also add attributes to a function. For example, you can set the `class()` and add a custom `print()` method.
 
 ### Primitive functions
 


### PR DESCRIPTION
At line 52, "For example, you can can set the", the duplicate "can" is redundant.
