### PR TITLE
Update Documenting-functions.rmd

### DIFF
--- a/Documenting-functions.rmd
+++ b/Documenting-functions.rmd
@@ -235,7 +235,7 @@ But you can't call any of the methods directly:
 
 This is good practice because it hides the internal implementation details of your functions.  Users should not rely on specific behaviour (for example, in this case we need to call `wday.default` for Date objects).  This makes it easier for you to change how the functions work in the future - for example, you could change from S3 to S4 dispatch.
 
-You only need to explicitly `@export` a method if it's for a generic defined in another package.  This is one of the easiest things to forget, and it creates subtle bugs that `R CMD check` doesn't report and are hard to track down.  Future versions of roxygen should hopefully make this easier.
+You only need to explicitly `@export` a method if its generic is defined in another package.  This is one of the easiest things to forget, and it creates subtle bugs that `R CMD check` doesn't report and are hard to track down.  Future versions of roxygen should hopefully make this easier.
 
 Most of the time you don't need to document S3 methods - particularly if they are for simple generics like `print`.  However, if your method is more complicated, you should document it.  In base R, you can find documentation for more complex methods like `predict.lm`, `predict.glm`, `anova.glm` and so on.
 


### PR DESCRIPTION
Makes it more clear when `@export` is needed for S3 methods.
