### PR TITLE
Add new best practice for R CMD CHECK integration

### DIFF
--- a/Testing.rmd
+++ b/Testing.rmd
@@ -305,13 +305,15 @@ This promotes a workflow where the _only_ way you test your code is through test
 
 ## R CMD check
 
-When developing a package, put your tests in `inst/tests` (note that your test files must begin with `test`), and then create a file `tests/run-all.R` (note that it must be a capital R), which contains the following code:
+Previously, best practice was to put all test files in `inst/tests` and ensure that R CMD check ran them by putting the following code in `tests/test-all.R`:
 
     library(testthat)
-    library(mypackage)
+    library(yourpackage)
+    test_package("yourpackage")
     
-    test_package("mypackage")
+Now, recommend practice is to put your tests in `tests/testthat`, and ensure R CMD check runs them by putting the following code in `tests/test-all.R`:
 
-This will evaluate your tests in the package namespace (so you can test non-exported functions), and it will throw an error if there are any test failures. This means you'll see the full report of test failures and `R CMD check` won't pass unless all tests pass.
-
-This also makes it easy for your users to check that you package works correctly in their run-time environment.
+    library(testthat)
+    test_check("yourpackage")
+    
+The advantage of this new structure is that the user has control over whether or not tests are installed using the --install-tests parameter to R CMD install, or INSTALL_opts = c("--install-tests") argument to install.packages(). I'm not sure why you wouldn't want to install the tests, but now you have the flexibility as requested by CRAN maintainers.


### PR DESCRIPTION
From `testthat` README, there is a new best practice to add tests to a package and ensure R CMD CHECK runs them
