### PR TITLE
Update C-interface.rmd

### DIFF
--- a/C-interface.rmd
+++ b/C-interface.rmd
@@ -52,6 +52,8 @@ To understand existing C code, it's useful to generate simple examples of your o
 
 You'll also need a C compiler. Windows users can use Duncan Murdoch's [Rtools](http://cran.r-project.org/bin/windows/Rtools/). Mac users will need the [Xcode command line tools](http://developer.apple.com/). Most Linux distributions will come with the necessary compilers.
 
+Under Windows it is necessary that the Rtools executables directory (typically `C:\Rtools\bin`) and the C compiler executables directory (typically `C:\Rtools\gcc-4.6.3\bin`) are included in the Windows `PATH` environment variable. You may need to reboot Windows before R can recognise these values.
+
 ## Calling C functions from R {#calling-c}
 
 Generally, calling a C function from R requires two pieces: a C function, and an R wrapper function that uses `.Call()`. The simple function below adds two numbers together and illustrates some of the complexities of coding in C:


### PR DESCRIPTION
Added a line about including Rtools and gcc in the Windows path. This is a common frustration when getting started. If one or both of these paths are missing, then C functions will not compile at all. (This edit motivated by tripping over this problem again.)
