### PR TITLE
added "begin" to "can't with _" for "binding names to values"

### DIFF
--- a/Environments.rmd
+++ b/Environments.rmd
@@ -576,7 +576,7 @@ Looking up variables in the calling environment rather than in the enclosing env
 
 Assignment is the act of binding (or rebinding) a name to a value in an environment. It is the counterpart to scoping, the set of rules that determines how to find the value associated with a name. Compared to most languages, R has extremely flexible tools for binding names to values. In fact, you can not only bind values to names, but you can also bind expressions (promises) or even functions, so that every time you access the value associated with a name, you get something different!
 
-You've probably used regular assignment in R thousands of times. Regular assignment creates a binding between a name and an object in the current environment. Names usually consist of letters, digits, `.` and `_`, and can't with `_`.  If you try to use a name that doesn't follow these rules, you get an error:
+You've probably used regular assignment in R thousands of times. Regular assignment creates a binding between a name and an object in the current environment. Names usually consist of letters, digits, `.` and `_`, and can't begin with `_`.  If you try to use a name that doesn't follow these rules, you get an error:
 
 ```{r, eval = FALSE}
 _abc <- 1


### PR DESCRIPTION
There was a missing word "begin" in the binding values to names section
