### PR TITLE
Fixing small typos and changing some wording

### DIFF
--- a/Environments.rmd
+++ b/Environments.rmd
@@ -100,7 +100,7 @@ Every environment has a parent, another environment. In diagrams, I'll represent
 embed_png("diagrams/environments.png/parents.png")
 ```
 
-We use the metaphor of a family to refer to environments. The grandparent of a environment is the parent's parent, and the ancestors include all parent environments up to the empty environment. It's rare to talk about the children of an environment because there are no back links: given an environment we have no way to find its children.
+We use the metaphor of a family to refer to environments. The grandparent of an environment is the parent's parent, and the ancestors include all parent environments up to the empty environment. It's rare to talk about the children of an environment because there are no back links: given an environment we have no way to find its children.
 
 Generally, an environment is similar to a list, with four important exceptions:
 
@@ -121,7 +121,7 @@ There are four special environments:
   This is the environment in which you normally work. The parent of the 
   global environment is the last package that you attached with `library()`.
 
-* The `baseenv()`, or base environemtn is the environment of the base package.
+* The `baseenv()`, or base environment is the environment of the base package.
   Its parent is the empty environment.
 
 * The `emptyenv()`, or empty environment, is the ultimate ancestor of all
@@ -206,7 +206,7 @@ rm("a", envir = e)
 ls(e)
 ```
 
-You can determine if a binding exists in a environment with `exists()`. Like `get()`, its default behaviour is to follow the regular scoping rules and look in parent environments. If you don't want this behavior, use `inherits = FALSE`:
+You can determine if a binding exists in an environment with `exists()`. Like `get()`, its default behaviour is to follow the regular scoping rules and look in parent environments. If you don't want this behavior, use `inherits = FALSE`:
 
 ```{r}
 x <- 10
@@ -234,7 +234,7 @@ globalenv() == environment()
 
 ## Recursing over environments {#env-recursion}
 
-Environments form a tree, so it's often convenient to write a recursive function. This section shows you how by applying your new knowledge of environments to understand the helpful `pryr::where()`. Given a name, `where()` that finds the environment _where_ it's defined, using R's regular scoping rules:
+Environments form a tree, so it's often convenient to write a recursive function. This section shows you how by applying your new knowledge of environments to understand the helpful `pryr::where()`. Given a name, `where()` finds the environment _where_ that name is defined, using R's regular scoping rules:
 
 ```{r}
 library(pryr)
@@ -386,13 +386,13 @@ embed_png("diagrams/environments.png/enclosing.png")
 
 ### Binding environments
 
-The previous diagram is too simple because functions don't have names. Instead, the name of a function is defined by a binding. The binding environments of a function are all the environments which have a binding to it. The following diagram better reflects relatively because the the enclosing environment contains a binding from `f` to the function:
+The previous diagram is too simple because functions don't have names. Instead, the name of a function is defined by a binding. The binding environments of a function are all the environments which have a binding to it. The following diagram better reflects this relationship because the enclosing environment contains a binding from `f` to the function:
 
 ```{r, echo = FALSE}
 embed_png("diagrams/environments.png/binding.png")
 ```
 
-In this case the enclosing and binding environments are the same.  They will be differently if you assign a function into a different environment:
+In this case the enclosing and binding environments are the same.  They will be different if you assign a function into a different environment:
 
 ```{r}
 e <- new.env()
@@ -635,29 +635,29 @@ There are two other special types of binding: delayed and active:
    when needed. We can create delayed bindings with the special assignment
    operator `%<d-%`, provided by the pryr package.
 
-  ```{r, cache = TRUE}
-  library(pryr)
-  system.time(b %<d-% {Sys.sleep(1); 1})
-  system.time(b)
-  ```
+```{r, cache = TRUE}
+library(pryr)
+system.time(b %<d-% {Sys.sleep(1); 1})
+system.time(b)
+```
 
-  `%<d-%` is a wrapper around the base `delayedAssign()` function, which you 
-  may need to use directly if you need more control. Delayed bindings are 
-  used to implement `autoload()`, which makes R behave as if the package data
-  is in memory, even though it's only loaded from disk when you ask for it.
+`%<d-%` is a wrapper around the base `delayedAssign()` function, which you 
+may need to use directly if you need more control. Delayed bindings are 
+used to implement `autoload()`, which makes R behave as if the package data
+is in memory, even though it's only loaded from disk when you ask for it.
   
 * __Active__ are not bound to a constant object. Instead, they're re-computed
   every time they're accessed:
 
-  ```{r}
-  x %<a-% runif(1)
-  x
-  x
-  ```
+```{r}
+x %<a-% runif(1)
+x
+x
+```
 
-  `%<a-%` is a wrapper for the base function `makeActiveBinding()`. You may 
-  want to use this function directly if you want more control. Active 
-  bindings are used to implement reference class fields.
+`%<a-%` is a wrapper for the base function `makeActiveBinding()`. You may 
+want to use this function directly if you want more control. Active 
+bindings are used to implement reference class fields.
 
 ### Exercises
 
@@ -758,7 +758,7 @@ set_a <- function(value) {
 }
 ```
 
-Returning the old value from setter functions is a good pattern because it makes it easier to reset the previous value in conjunction with `on.exit()` (See more in [on exit](#on-exit). )
+Returning the old value from setter functions is a good pattern because it makes it easier to reset the previous value in conjunction with `on.exit()` (See more in [on exit](#on-exit)).
 
 ### As a hashmap
 


### PR DESCRIPTION
In addition to fixing small typos, I made a change to two phrases that seemed like mistakes and my changes might not necessarily be (1) correct or (2) your preferred wording.

Two code blocks were un-indented, along with surrounding paragraphs, to make the code blocks render correctly (I think).
