### PR TITLE
description does not match diagram

### DIFF
--- a/Environments.rmd
+++ b/Environments.rmd
@@ -283,10 +283,10 @@ embed_png("diagrams/environments.png/where-ex.png")
 
 * If you're looking for `a`, `where()` will find it in the first environment.
 
-* If you're looking for `b`, it's not in the first environment, 
+* If you're looking for `c`, it's not in the first environment, 
   so `where()` will look in its parent and find it there.
 
-* If you're looking for `c`, it's not in the first environment, or the
+* If you're looking for `b`, it's not in the first environment, or the
   second environment, so `where()` reaches the empty environment
   and throws an error.
 


### PR DESCRIPTION
re. diagrams/environments.png/where-ex.png"):  The description said 'b' was the second environment and 'c' was absent.  The image showed 'c' but not 'b'.  This patch fixes that obvious error.
