### PR TITLE
g() or i()?

### DIFF
--- a/Environments.rmd
+++ b/Environments.rmd
@@ -484,7 +484,7 @@ You'll learn more about function factories in [functional programming](#function
 
 ### Calling environments
 
-Look at the following code. What do you expect `g()` to return when the code is run?
+Look at the following code. What do you expect `i()` to return when the code is run?
 
 ```{r, eval = FALSE}
 h <- function() {


### PR DESCRIPTION
You ask, "What do you expect `g()` to return when the code is run?" But there is no g().  Do you mean i()?  This suggested change assumes so.  If that's not what you meant, please rewrite accordingly.  Spencer 
p.s.  Google Chrome locked up trying to make this change, so I switched to Firefox.  I mention this in case you get a duplicate.
