### PR TITLE
removed reference to roxygen3

### DIFF
--- a/Documenting-functions.rmd
+++ b/Documenting-functions.rmd
@@ -25,8 +25,6 @@ This workflow has a number of advantages over writing `.Rd` files by hand:
 * Abstracts over the differences in documenting S3 and S4 methods, generics 
   and classes so that they behave basically the same.
 
-**Note**: this chapter currently describes the use of the in-development [roxygen3](http://github.com/hadley/roxygen3) package. This will be merged back into roxygen2 in the near future.
-
 This chapter will proceed as follows. First, we'll discuss the basic documentation process, what each step does, and how to see the output at every stage. Next we'll show you, at a high-level, how to document all the different types of R objects (functions, datasets, s3 methods, s4 methods, s4 classes, r5 classes, and packages). After that you'll learn how to format text within the documentation.
 
 ## Help


### PR DESCRIPTION
**Only accept this change if** as I suspect, the roxygen3 features described here have merged into roxygen2

The [roxygen3 README](https://github.com/hadley/roxygen3/blob/master/README.md) indicates development has stopped ... the deleted text was added oct 2012 (e6ebfd22) and roxygen3 was deprecated 11/2013; so it seems that this note is no longer relevant.
