### PR TITLE
Update Computing-on-the-language.rmd

### DIFF
--- a/Computing-on-the-language.rmd
+++ b/Computing-on-the-language.rmd
@@ -160,7 +160,7 @@ subset(sample_df, b == c)
 
 How does `subset()` work? We've already seen how to capture an argument's expression rather than its result, so we just need to figure out how to evaluate that expression in the right context. Specifically, we want `x` to be interpreted as `sample_df$x`, not `globalenv()$x`. To do this, we need `eval()`. This function takes an expression and evaluates it in the specified environment.
 
-Before we can explore `eval()`, we need one more useful function: `quote()`. It captures an unevaluated expression like `substitute()`. Because you don't need to use it inside a function, `substitute()` is useful for interactive experimentation.
+Before we can explore `eval()`, we need one more useful function: `quote()`. It captures an unevaluated expression like `substitute()`. Because you don't need to use it inside a function, `quote()` is useful for interactive experimentation.
 
 ```{r}
 quote(1:10)


### PR DESCRIPTION
Typo: Change the last substitute to quote on line 163.

Before we can explore `eval()`, we need one more useful function: `quote()`. It captures an unevaluated expression like `substitute()`. Because you don't need to use it inside a function, `quote()` is useful for interactive experimentation.
