### PR TITLE
Update Documenting-functions.rmd

### DIFF
--- a/Documenting-functions.rmd
+++ b/Documenting-functions.rmd
@@ -245,8 +245,6 @@ The same rules apply when documenting S4 generics and methods:
 
 * You don't need to export methods if they're for a generic you defined (just export the generic). Export all methods for generics defined in other packages.
 
-* Use `@genericMethods` in the generic documentation if you want an automated listing of all methods implemented for the generic.
-
 ## Documenting R5 methods
 
 Currently there is no way to use roxygen to document R5 methods.  Use the standard docstring format. Alternatively, use roxygen to document an object with `@name` named by convention and assign it to `NULL`. For example, if object `obj` has method `getName`, then document the method as follows, using the convention to replace the `$` with `_`:


### PR DESCRIPTION
Removed a line about the `@genericMethods` tag, which is not implemented in roxygen2.
