### PR TITLE
May not return value in this else-if branch

### DIFF
--- a/Expressions.rmd
+++ b/Expressions.rmd
@@ -694,6 +694,7 @@ logical_abbr <- function(x) {
     for (i in seq_along(x)) {
       if (logical_abbr(x[[i]])) return(TRUE)
     }
+    FALSE
   } else {
     stop("Don't know how to handle type ", typeof(x), 
       call. = FALSE)


### PR DESCRIPTION
test case:

``` rconsole
> logical_abbr(quote(function(x=TRUE, na.rm = TRUE) FALSE ))
Error in if (logical_abbr(x[[i]])) return(TRUE) : 
  argument is of length zero
```

The credit should go to [superdesolator](http://cos.name/cn/profile/377380) who found the problem in the [thread](http://cos.name/cn/topic/157415).
