### PR TITLE
Update Documenting-functions.rmd

### DIFF
--- a/Documenting-functions.rmd
+++ b/Documenting-functions.rmd
@@ -25,7 +25,7 @@ This workflow has a number of advantages over writing `.Rd` files by hand:
 * Abstracts over the differences in documenting S3 and S4 methods, generics 
   and classes so that they behave basically the same.
 
-This chapter will proceed as follows. First, we'll discuss the basic documentation process, what each step does, and how to see the output at every stage. Next we'll show you, at a high-level, how to document all the different types of R objects (functions, datasets, s3 methods, s4 methods, s4 classes, r5 classes, and packages). After that you'll learn how to format text within the documentation.
+This chapter will proceed as follows. First, we'll discuss the basic documentation process, what each step does, and how to see the output at every stage. Next we'll show you, at a high-level, how to document all the different types of R objects (functions, datasets, s3 methods, s4 methods, s4 classes, RC classes, and packages). After that you'll learn how to format text within the documentation.
 
 ## Help
 
@@ -245,9 +245,9 @@ The same rules apply when documenting S4 generics and methods:
 
 * You don't need to export methods if they're for a generic you defined (just export the generic). Export all methods for generics defined in other packages.
 
-## Documenting R5 methods
+## Documenting RC methods
 
-Currently there is no way to use roxygen to document R5 methods.  Use the standard docstring format. Alternatively, use roxygen to document an object with `@name` named by convention and assign it to `NULL`. For example, if object `obj` has method `getName`, then document the method as follows, using the convention to replace the `$` with `_`:
+Currently there is no way to use roxygen to document RC methods.  Use the standard docstring format. Alternatively, use roxygen to document an object with `@name` named by convention and assign it to `NULL`. For example, if object `obj` has method `getName`, then document the method as follows, using the convention to replace the `$` with `_`:
 
     #' @title Get the name of the object
     #' ...
@@ -270,7 +270,7 @@ Typically you should document the `setClass` call, and if present, the construct
 
 Export the class if you want other developers to be able to write subclasses of your class.  Export the constructor if you want users to be able to use it.
 
-### Documenting an R5 class
+### Documenting an RC class
 
 
 ## Documenting datasets


### PR DESCRIPTION
The terminology RC is used in an earlier chapter about OO programming in R. As a reader I get confused about reading about R5 classes all of the sudden.

The link, in the link section to the left, should also be updated to RC from R5 if this proposal is approved. Cannot find where to do this update in these pages.
