### PR TITLE
Dead link due to new URL for R packages book

### DIFF
--- a/Exceptions-Debugging.rmd
+++ b/Exceptions-Debugging.rmd
@@ -93,7 +93,7 @@ While the procedure below is by no means foolproof, it will hopefully help you t
     exists. This is one reason why automated test suites are important when
     producing high-quality code. Unfortunately, automated testing is outside the
     scope of this book, but you can read more about it at
-    <http://adv-r.had.co.nz/Testing.html>.
+    <http://r-pkgs.had.co.nz/tests.html>.
 
 2. __Make it repeatable__
 


### PR DESCRIPTION
The unpublished book about R package development recently changed URL. This created a dead link in this chapter.

Also, in the link section on this page: http://adv-r.had.co.nz/.
Should the link denoted "Package development" be removed or updated?
