### PR TITLE
Update Expressions.rmd

### DIFF
--- a/Expressions.rmd
+++ b/Expressions.rmd
@@ -1,5 +1,5 @@
 ---
-title: Metaprogramming
+title: Expressions
 layout: default
 output: bookdown::html_chapter
 ---
@@ -8,7 +8,7 @@ output: bookdown::html_chapter
 library(pryr)
 ```
 
-# Metaprogramming {#metaprogramming}
+# Expressions {#metaprogramming}
 
 In [non-standard evaluation](#nse), you learned the basics of accessing and evaluating the expressions underlying computation in R. In this chapter, you'll learn how to manipulate these expressions with code. You're going to learn how to metaprogram: how to create programs with other programs! \index{metaprogramming} \index{computing on the language|see{metaprogramming}}
 


### PR DESCRIPTION
The main title for the three chapters is "Metaprogramming", but the title is "Metaprogramming" for this chapter when the link says "Expressions"?

Since I assume #metaprogamming is a label with possible cross references, I don't update this.

Other chapters where the link and title differs are:
Exceptions and debugging (link name)
Profiling (link name)
Rcpp (link name)
