### PR TITLE
Fixing Typos

### DIFF
--- a/extras/redirects.R
+++ b/extras/redirects.R
@@ -9,7 +9,7 @@ redirects <- c(
   "Documenting-functions.html" = "man.html",
   "Namespaces.html" = "namespace.html",
   "Style.html" = "style.html",
-  "Testing.html" = "test.html",
+  "Testing.html" = "tests.html",
   "Git.html" = "git.html",
   "Release.html" = "release.html"
 )


### PR DESCRIPTION
The file name in r-pkgs is 'tests.rmd'. 

The link http://adv-r.had.co.nz/Testing.html in Exceptions-Debugging.rmd uses this redirect. Another option would be to just make a direct link to the R Packages website. But, given R Packages is still in development, maybe the redirect is still best...
