### PR TITLE
Some unexpected behavior I tested in R

### DIFF
--- a/Subsetting.rmd
+++ b/Subsetting.rmd
@@ -445,10 +445,14 @@ x
 
 # You can't combine integer indices with NA
 x[c(1, NA)] <- c(1, 2)
+# but this is okay
+x[c(1, NA)] <- 10
 # But you can combine logical indices with NA
 # (where they're treated as false).
 x[c(T, F, NA)] <- 1
 x
+# but this is not okay
+x[c(T, F, NA)] <- c(10, 20, 30)
 
 # This is mostly useful when conditionally modifying vectors
 df <- data.frame(a = c(1, 10, NA))


### PR DESCRIPTION
The behavior described about NA index is not correct. It is not a straightforward case of disallowing NA + integer indices but allowing NA + logical indices. Please see examples.
