### PR TITLE
rename label #metaprogramming to #expressions to match title

### DIFF
--- a/Computing-on-the-language.rmd
+++ b/Computing-on-the-language.rmd
@@ -73,7 +73,7 @@ y <- 13
 f(x + y^2)
 ```
 
-For now, we won't worry about exactly what `substitute()` returns (that's the topic of [the following chapter](#metaprogramming)), but we'll call it an expression.
+For now, we won't worry about exactly what `substitute()` returns (that's the topic of [the following chapter](#expressions)), but we'll call it an expression.
 
 `substitute()` works because function arguments are represented by a special type of object called a __promise__. A promise captures the expression needed to compute the value and the environment in which to compute it. You're not normally aware of promises because the first time you access a promise its code is evaluated in its environment, yielding a value. \index{promises}
 

--- a/Expressions.rmd
+++ b/Expressions.rmd
@@ -8,7 +8,7 @@ output: bookdown::html_chapter
 library(pryr)
 ```
 
-# Expressions {#metaprogramming}
+# Expressions {#expressions}
 
 In [non-standard evaluation](#nse), you learned the basics of accessing and evaluating the expressions underlying computation in R. In this chapter, you'll learn how to manipulate these expressions with code. You're going to learn how to metaprogram: how to create programs with other programs! \index{metaprogramming} \index{computing on the language|see{metaprogramming}}
 

--- a/Function-operators.rmd
+++ b/Function-operators.rmd
@@ -498,7 +498,7 @@ The next step up in complexity is to modify the inputs of a function. Again, you
 
 ### Prefilling function arguments: partial function application
 
-A common use of anonymous functions is to make a variant of a function that has certain arguments "filled in" already. This is called "partial function application", and is implemented by `pryr::partial()`. Once you have read [metaprogramming](#metaprogramming), I encourage you to read the source code for `partial()` and figure out how it works --- it's only 5 lines of code! \index{partial application} \index{currying} \indexc{partial()}
+A common use of anonymous functions is to make a variant of a function that has certain arguments "filled in" already. This is called "partial function application", and is implemented by `pryr::partial()`. Once you have read [expressions](#expressions), I encourage you to read the source code for `partial()` and figure out how it works --- it's only 5 lines of code! \index{partial application} \index{currying} \indexc{partial()}
 
 `partial()` allows us to replace code like
 

--- a/Functions.rmd
+++ b/Functions.rmd
@@ -417,7 +417,7 @@ sapply(x, "[", 2)
 sapply(x, function(x) x[2])
 ```
 
-Remembering that everything that happens in R is a function call will help you in [metaprogramming](#metaprogramming).
+Remembering that everything that happens in R is a function call will help you in [expressions](#expressions).
 
 ## Function arguments {#function-arguments}
 


### PR DESCRIPTION
The title of this chapter was renamed in #583. This commit changes the label and cross-references to avoid future missunderstandings!
