### PR TITLE
Fix typos in "Functional Programming"

### DIFF
--- a/Functional-programming.rmd
+++ b/Functional-programming.rmd
@@ -367,7 +367,7 @@ Closures are useful for making function factories, and are one way to manage mut
 
 ### Function factories
 
-A function factory is a factor for making new functions. We've already seen two examples of function factories, `missing_fixer()` and `power()`. You call it with arguments that describe the descired actions, and it returns a function that will do the work for you. For `missing_fixer()` and `power()`, there's not much benefit in using a function factory instead of a single function with multiple arguments. Function factories are most useful when: \index{function factories}
+A function factory is a factory for making new functions. We've already seen two examples of function factories, `missing_fixer()` and `power()`. You call it with arguments that describe the desired actions, and it returns a function that will do the work for you. For `missing_fixer()` and `power()`, there's not much benefit in using a function factory instead of a single function with multiple arguments. Function factories are most useful when: \index{function factories}
 
 * The different levels are more complex, with multiple arguments and 
   complicated bodies.


### PR DESCRIPTION
"factor" -> "factory"
"descired" -> "desired"
