### PR TITLE
TYPO: asLogical() takes LGLSXP (was INTSXP)

### DIFF
--- a/C-interface.rmd
+++ b/C-interface.rmd
@@ -353,7 +353,7 @@ If you're working with lists, use `shallow_duplicate()` to make a shallow copy; 
 
 There are a few helper functions that turn length one R vectors into C scalars:
 
-* `asLogical(x): INTSXP -> int`
+* `asLogical(x): LGLSXP -> int`
 * `asInteger(x): INTSXP -> int`
 * `asReal(x): REALSXP -> double`
 * `CHAR(asChar(x)): STRSXP -> const char*`


### PR DESCRIPTION
In Section 'Coercing scalars' [http://adv-r.had.co.nz/C-interface.html#c-data-structures], I think you meant `asLogical(x): LGLSXP -> int`.
