### PR TITLE
Update Data-structures.rmd

### DIFF
--- a/Data-structures.rmd
+++ b/Data-structures.rmd
@@ -65,7 +65,7 @@ The basic data structure in R is the vector. Vectors come in two flavours: atomi
 
 They differ in the types of their elements: all elements of an atomic vector must be the same type, whereas the elements of a list can have different types.
 
-NB: `is.vector()` does not test if an object is a vector. Instead it returns `TRUE` only if the object is a vector with no attributes apart from names. Use `is.atomic(x) || is.list(x)` to test if an object is actually a vector.
+NB: `is.vector()` does not test if an object is a vector. Instead it returns `TRUE` only if the object is a vector with no attributes apart from names. Use `is.atomic(x) && is.vector(x)` to test if an object is actually a vector.
 
 ### Atomic vectors
 


### PR DESCRIPTION
"I assign the copyright of this contribution to Hadley Wickham".

I feel this was probably a typo:

   x <- list() 
   print(is.atomic(x) || is.list(x))

prints TRUE, I believe it will print TRUE no matter what kind of list is passed.

   x <- list()
   print(is.atomic(x) && is.vector(x)) #FALSE
   x <- list(a=1, b=c(1,2,3), c=list())
   print(is.atomic(x) && is.vector(x)) #FALSE
   x <- c(1,2,3)
   print(is.atomic(x) && is.vector(x)) #TRUE

I hope I didn't miss something.
