### PR TITLE
Update Subsetting.rmd

### DIFF
--- a/Subsetting.rmd
+++ b/Subsetting.rmd
@@ -232,7 +232,7 @@ S3 objects are made up of atomic vectors, arrays, and lists, so you can always p
 
 ### S4 objects
 
-There are also two additional subsetting operators that are needed for S4 objects: `@` (equivalent to `$`), and `slot()` (equivalent to `[[`). `@` is more restrictive than `$` in that it will return an error if the slot does not exist. These are described in more detail in [the OO field guide](#s4). \index{subsetting!S4} \index{S4!subsetting} \indexc{@}
+There are also two additional subsetting operators that are needed for S4 objects: `@` (equivalent to `$`), and `slot()` (equivalent to `[[`). `@` is more restrictive than `$` in that it will return an error if the slot does not exist. These are described in more detail in the [OO field guide](#s4). \index{subsetting!S4} \index{S4!subsetting} \indexc{@}
 
 ### Exercises
 


### PR DESCRIPTION
Link to OO field guide broken. I think this change should fix issue, but can't test to be sure and how the magic linking between section name and <a> tag is beyond my limited markdown knowledge. This proposed change is just a pattern matching guess.
