### PR TITLE
small bugfixes in beyond-exception-handling.rmd

### DIFF
--- a/beyond-exception-handling.rmd
+++ b/beyond-exception-handling.rmd
@@ -140,7 +140,7 @@ Conditional classes are regular S3 classes, built up from a list with components
 condition <- function(subclass, message, call = sys.call(-1), ...) {
   structure(
     class = c(subclass, "condition"),
-    list(message = message, call = call),
+    list(message = message, call = call, ...)
   )
 }
 ```
@@ -237,7 +237,7 @@ parse_log_file <- function(file) {
   
   lapply(lines, function(text) {
     tryCatch(
-      malformed_log_entry = function() NULL,
+      malformed_log_entry = function(e) NULL,
       parse_log_entry(text)
     )
   })
@@ -324,7 +324,7 @@ parse_log_file <- function(file) {
   lapply(lines, function(text) {
     withRestarts(
       parse_log_entry(text),
-      skip_log_entry = function() NULL
+      skip_log_entry = function(e) NULL
     )
   })
 }
@@ -409,7 +409,7 @@ log_analyzer <- function() {
   logs <- find_all_logs()
   
   withCallingHandlers(
-    malformed_log_entry_error = function() invokeRestart("skip_log_entry"),
+    malformed_log_entry_error = function(e) invokeRestart("skip_log_entry"),
     lapply(logs, analyze_log)
   )
 }


### PR DESCRIPTION
* from `malformed_log_entry_error()` I inferred that `...` in `condition()` should be used to pass further elements to the underlying `list` which is returned

* some anonymous functions used in `tryCatch()`, `withRestarts()` and `withCallingHandlers()` didn't take any arguments, whereas in fact they should take one