### PR TITLE
Update beyond-exception-handling.rmd

### DIFF
--- a/beyond-exception-handling.rmd
+++ b/beyond-exception-handling.rmd
@@ -153,7 +153,7 @@ the argument that was passed to `parse_log_entry()`, like this:
 ```{r malformed_log_entry_error}
 malformed_log_entry_error <- function(text) {
   msg <- paste0("Malformed log entry: ", text)
-  condition(c("malformed_log_entry_entry", "error"),
+  condition(c("malformed_log_entry_error", "error"),
     message = msg, 
     text = text
   )


### PR DESCRIPTION
Fix typo in code.
3 Things I noticed
1. skip_log_entry really doesn't really skip the entry, but puts a NULL on the list of log_entrys which is different (I think)
2. I couldn't find a findRestarts() function, and the paragraph describing the interaction in the debugger is true for lisp, but I don't think its true for R
3. It isn't clear why in tryCatch, withCallingHandlers, and withRestarts, the order of arguments in the examples varies where some times expression is first and handlers follow and sometimes handlers are first and expression follows.
