### PR TITLE
method name <-> class name

### DIFF
--- a/OO-essentials.rmd
+++ b/OO-essentials.rmd
@@ -134,7 +134,7 @@ Some S3 generics, like `[`, `sum()`, and `cbind()`, don't call `UseMethod()` bec
 
 Given a class, the job of an S3 generic is to call the right S3 method. You can recognise S3 methods by their names, which look like `generic.class()`. For example, the Date method for the `mean()` generic is called `mean.Date()`, and the factor method for `print()` is called `print.factor()`.  \index{methods!S3} \index{S3!methods}
 
-This is the reason that most modern style guides discourage the use of `.` in function names: it makes them look like S3 methods. For example, is `t.test()` the `test` method for `t` objects? Similarly, the use of `.` in class names can also be confusing: is `print.data.frame()` the `print()` method for `data.frames`, or the `print.data()` method for `frames`?  `pryr::ftype()` knows about these exceptions, so you can use it to figure out if a function is an S3 method or generic:
+This is the reason that most modern style guides discourage the use of `.` in function names: it makes them look like S3 methods. For example, is `t.test()` the `t` method for `test` objects? Similarly, the use of `.` in class names can also be confusing: is `print.data.frame()` the `print()` method for `data.frames`, or the `print.data()` method for `frames`?  `pryr::ftype()` knows about these exceptions, so you can use it to figure out if a function is an S3 method or generic:
 
 ```{r}
 ftype(t.data.frame) # data frame method for t()


### PR DESCRIPTION
In `t.test`, if it was an S3 method, "test" would refer to the class, not "t'.