### PR TITLE
Made source of `subs()` clear.

### DIFF
--- a/Computing-on-the-language.rmd
+++ b/Computing-on-the-language.rmd
@@ -644,13 +644,13 @@ This uses the `alist()` function which simply captures all its arguments. This f
 
 ### Exercises
 
-1.  Use `subs()` to convert the LHS to the RHS for each of the following pairs:
+1.  Use `pryr::subs()` to convert the LHS to the RHS for each of the following pairs:
     * `a + b + c` -> `a * b * c`
     * `f(g(a, b), c)` -> `(a + b) * c`
     * `f(a < b, c, d)` -> `if (a < b) c else d`
 
 2.  For each of the following pairs of expressions, describe why you can't
-    use `subs()` to convert one to the other.
+    use `pryr::subs()` to convert one to the other.
     * `a + b + c` -> `a + b * c`
     * `f(a, b)` -> `f(a, b, c)`
     * `f(a, b, c)` -> `f(a, b)`


### PR DESCRIPTION
The function `pry::subs()` is used before the fact that it comes from `pryr` is made clear.