### PR TITLE
Update OO-essentials.rmd

### DIFF
--- a/OO-essentials.rmd
+++ b/OO-essentials.rmd
@@ -39,7 +39,7 @@ R's three OO systems differ in how classes and methods are defined:
   makes them harder to reason about, but allows them to solve problems that 
   are difficult to solve with S3 or S4.
 
-There's also one other system that's not quite OO, but it's important to mention here:
+There is also another system that is not quite OO, but is important to mention here:
 
 * __base types__, the internal C-level types that underlie the other OO 
   systems. Base types are mostly manipulated using C code, but they're 
@@ -69,10 +69,10 @@ Think you know this material already? If you can answer the following questions 
 ##### Outline
 
 * [Base types](#base-types) teaches you about R's base object system. Only
-  R-core can add new classes to this system, but it's important to know about
+  R-core can add new classes to this system, but it is important to know about
   because it underpins the three other systems.
   
-* [S3](#s3) shows you the basics of the S3 object system. It's the simplest
+* [S3](#s3) shows you the basics of the S3 object system. It is the simplest
   and most commonly used OO system.
   
 * [S4](#s4) discusses the more formal and rigorous S4 system.
@@ -102,15 +102,15 @@ is.primitive(sum)
 
 You may have heard of `mode()` and `storage.mode()`. I recommend ignoring these functions because they're just aliases of the names returned by `typeof()`, and exist solely for S compatibility. Read their source code if you want to understand exactly what they do. \indexc{mode()}
 
-Functions that behave differently for different base types are almost always written in C, where dispatch occurs using switch statements (e.g., `switch(TYPEOF(x))`). Even if you never write C code, it's important to understand base types because everything else is built on top of them: S3 objects can be built on top of any base type, S4 objects use a special base type, and RC objects are a combination of S4 and environments (another base type). To see if an object is a pure base type, i.e., it doesn't also have S3, S4, or RC behaviour, check that `is.object(x)` returns `FALSE`.
+Functions that behave differently for different base types are almost always written in C, where dispatch occurs using switch statements (e.g., `switch(TYPEOF(x))`). Even if you never write C code, it is important to understand base types because everything else is built on top of them: S3 objects can be built on top of any base type, S4 objects use a special base type, and RC objects are a combination of S4 and environments (another base type). To see if an object is a pure base type, i.e., it doesn't also have S3, S4, or RC behaviour, check that `is.object(x)` returns `FALSE`.
 
 ## S3 {#s3}
 
-S3 is R's first and simplest OO system. It is the only OO system used in the base and stats packages, and it's the most commonly used system in CRAN packages. S3 is informal and ad hoc, but it has a certain elegance in its minimalism: you can't take away any part of it and still have a useful OO system. \index{S3} \index{objects!S3|see{S3}}
+S3 is R's first and simplest OO system. It is the only OO system used in the base and stats packages, and it is the most commonly used system in CRAN packages. S3 is informal and ad hoc, but it has a certain elegance in its minimalism: you can't take away any part of it and still have a useful OO system. \index{S3} \index{objects!S3|see{S3}}
 
 ### Recognising objects, generic functions, and methods
 
-Most objects that you encounter are S3 objects. But unfortunately there's no simple way to test if an object is an S3 object in base R. The closest you can come is `is.object(x) & !isS4(x)`, i.e., it's an object, but not S4. An easier way is to use `pryr::otype()`: \indexc{otype()}
+Most objects that you encounter are S3 objects. But unfortunately there is no simple way to test if an object is an S3 object in base R. The closest you can come is `is.object(x) & !isS4(x)`, i.e., it is an object, but not S4. An easier way is to use `pryr::otype()`: \indexc{otype()}
 
 ```{r, message = FALSE}
 library(pryr)
@@ -123,7 +123,7 @@ otype(df$y)  # A factor is
 
 In S3, methods belong to functions, called __generic functions__, or generics for short. S3 methods do not belong to objects or classes. This is different from most other programming languages, but is a legitimate OO style. \index{functions!generics|see{generics}} \index{S3!generics} \index{generics!S3}
 
-To determine if a function is an S3 generic, you can inspect its source code for a call to `UseMethod()`: that's the function that figures out the correct method to call, the process of __method dispatch__. Similar to `otype()`, pryr also provides `ftype()` which describes the object system, if any, associated with a function: \indexc{UseMethod()}
+To determine if a function is an S3 generic, you can inspect its source code for a call to `UseMethod()`: that is the function that figures out the correct method to call, the process of __method dispatch__. Similar to `otype()`, pryr also provides `ftype()` which describes the object system, if any, associated with a function: \indexc{UseMethod()}
 
 ```{r}
 mean
@@ -156,7 +156,7 @@ You can also list all generics that have a method for a given class:
 methods(class = "ts")
 ```
 
-There's no way to list all S3 classes, as you'll learn in the following section.
+There is no way to list all S3 classes, as you'll learn in the following section.
 
 ### Defining classes and creating objects
 
@@ -191,7 +191,7 @@ foo <- function(x) {
 }
 ```
 
-You should use it if it's available (like for `factor()` and `data.frame()`). This ensures that you're creating the class with the correct components. Constructor functions usually have the same name as the class.
+You should use it if it is available (like for `factor()` and `data.frame()`). This ensures that you're creating the class with the correct components. Constructor functions usually have the same name as the class.
 
 Apart from developer supplied constructor functions, S3 has no checks for correctness. This means you can change the class of existing objects:
 
@@ -213,7 +213,7 @@ If you've used other OO languages, this might make you feel queasy. But surprisi
 
 ### Creating new methods and generics
 
-To add a new generic, create a function that calls `UseMethod()`. `UseMethod()` takes two arguments: the name of the generic function, and the argument to use for method dispatch. If you omit the second argument it will dispatch on the first argument to the function. There's no need to pass any of the arguments of the generic to `UseMethod()` and you shouldn't do so. `UseMethod()` uses black magic to find them out for itself. \indexc{UseMethod()} \index{S3!new generic}
+To add a new generic, create a function that calls `UseMethod()`. `UseMethod()` takes two arguments: the name of the generic function, and the argument to use for method dispatch. If you omit the second argument it will dispatch on the first argument to the function. There is no need to pass any of the arguments of the generic to `UseMethod()` and you shouldn't do so. `UseMethod()` uses black magic to find them out for itself. \indexc{UseMethod()} \index{S3!new generic}
 
 ```{r}
 f <- function(x) UseMethod("f")
@@ -236,7 +236,7 @@ mean.a <- function(x) "a"
 mean(a)
 ```
 
-As you can see, there's no check to make sure that the method returns the class compatible with the generic. It's up to you to make sure that your method doesn't violate the expectations of existing code.
+As you can see, there is no check to make sure that the method returns the class compatible with the generic. It is up to you to make sure that your method doesn't violate the expectations of existing code.
 
 ### Method dispatch
 
@@ -263,7 +263,7 @@ Group generic methods add a little more complexity. Group generics make it possi
 
 Group generics are a relatively advanced technique and are beyond the scope of this chapter but you can find out more about them in `?groupGeneric`. The most important thing to take away from this is to recognise that `Math`, `Ops`, `Summary`, and `Complex` aren't real functions, but instead represent groups of functions. Note that inside a group generic function a special variable `.Generic` provides the actual generic function called.
 
-If you have complex class hierarchies it's sometimes useful to call the "parent" method. It's a little bit tricky to define exactly what that means, but it's basically the method that would have been called if the current method did not exist. Again, this is an advanced technique: you can read about it in `?NextMethod`. \indexc{NextMethod()}
+If you have complex class hierarchies it is sometimes useful to call the "parent" method. It is a little bit tricky to define exactly what that means, but it is basically the method that would have been called if the current method did not exist. Again, this is an advanced technique: you can read about it in `?NextMethod`. \indexc{NextMethod()}
 
 Because methods are normal R functions, you can call them directly:
 
@@ -315,7 +315,7 @@ iclass(array(1.5))
 
 1.  `UseMethod()` calls methods in a special way. Predict what the following
      code will return, then run it and read the help for `UseMethod()` to 
-    figure out what's going on. Write down the rules in the simplest form
+    figure out what is going on. Write down the rules in the simplest form
     possible.
 
     ```{r, eval = FALSE}
@@ -368,9 +368,9 @@ S4 works in a similar way to S3, but it adds formality and rigour. Methods still
 * There is a special operator, `@`, for extracting slots (aka fields)
   from an S4 object.
 
-All S4 related code is stored in the `methods` package. This package is always available when you're running R interactively, but may not be available when running R in batch mode. For this reason, it's a good idea to include an explicit `library(methods)` whenever you're using S4.
+All S4 related code is stored in the `methods` package. This package is always available when you're running R interactively, but may not be available when running R in batch mode. For this reason, it is a good idea to include an explicit `library(methods)` whenever you're using S4.
 
-S4 is a rich and complex system. There's no way to explain it fully in a few pages. Here I'll focus on the key ideas underlying S4 so you can use existing S4 objects effectively. To learn more, some good references are:
+S4 is a rich and complex system. There is no way to explain it fully in a few pages. Here I'll focus on the key ideas underlying S4 so you can use existing S4 objects effectively. To learn more, some good references are:
 
 * [S4 system development in Bioconductor](http://www.bioconductor.org/help/course-materials/2010/AdvancedR/S4InBioconductor.pdf)
 
@@ -413,7 +413,7 @@ is(fit)
 is(fit, "mle")
 ```
 
-You can get a list of all S4 generics with `getGenerics()`, and a list of all S4 classes with `getClasses()`. This list includes shim classes for S3 classes and base types. You can list all S4 methods with `showMethods()`, optionally restricting selection either by `generic` or by `class` (or both). It's also a good idea to supply `where = search()` to restrict the search to methods available in the global environment.
+You can get a list of all S4 generics with `getGenerics()`, and a list of all S4 classes with `getClasses()`. This list includes shim classes for S3 classes and base types. You can list all S4 methods with `showMethods()`, optionally restricting selection either by `generic` or by `class` (or both). It is also a good idea to supply `where = search()` to restrict the search to methods available in the global environment.
 
 ### Defining classes and creating objects
 
@@ -475,7 +475,7 @@ rn@min
 rn@.Data
 ```
 
-Since R is an interactive programming language, it's possible to create new classes or redefine existing classes at any time. This can be a problem when you're interactively experimenting with S4. If you modify a class, make sure you also recreate any objects of that class, otherwise you'll end up with invalid objects.
+Since R is an interactive programming language, it is possible to create new classes or redefine existing classes at any time. This can be a problem when you're interactively experimenting with S4. If you modify a class, make sure you also recreate any objects of that class, otherwise you'll end up with invalid objects.
 
 ### Creating new methods and generics
 
@@ -505,7 +505,7 @@ setGeneric("myGeneric", function(x) {
 
 If an S4 generic dispatches on a single class with a single parent, then S4 method dispatch is the same as S3 dispatch. The main difference is how you set up default values: S4 uses the special class `ANY` to match any class and "missing" to match a missing argument. Like S3, S4 also has group generics, documented in `?S4groupGeneric`, and a way to call the "parent" method, `callNextMethod()`. \index{S4!method dispatch rules}
 
-Method dispatch becomes considerably more complicated if you dispatch on multiple arguments, or if your classes use multiple inheritance. The rules are described in `?Methods`, but they are complicated and it's difficult to predict which method will be called. For this reason, I strongly recommend avoiding multiple inheritance and multiple dispatch unless absolutely necessary.
+Method dispatch becomes considerably more complicated if you dispatch on multiple arguments, or if your classes use multiple inheritance. The rules are described in `?Methods`, but they are complicated and it is difficult to predict which method will be called. For this reason, I strongly recommend avoiding multiple inheritance and multiple dispatch unless absolutely necessary.
 
 Finally, there are two methods that find which method gets called given the specification of a generic call:
 
@@ -543,7 +543,7 @@ These properties make RC objects behave more like objects do in most other progr
 
 Since there aren't any reference classes provided by the base R packages, we'll start by creating one. RC classes are best used for describing stateful objects, objects that change over time, so we'll create a simple class to model a bank account. \index{RC!classes} \index{classes!RC}
 
-Creating a new RC class is similar to creating a new S4 class, but you use `setRefClass()` instead of `setClass()`. The first, and only required argument, is an alphanumeric __name__. While you can use `new()` to create new RC objects, it's good style to use the object returned by `setRefClass()` to generate new objects. (You can also do that with S4 classes, but it's less common.) \indexc{setRefClass()}
+Creating a new RC class is similar to creating a new S4 class, but you use `setRefClass()` instead of `setClass()`. The first, and only required argument, is an alphanumeric __name__. While you can use `new()` to create new RC objects, it is good style to use the object returned by `setRefClass()` to generate new objects. (You can also do that with S4 classes, but it is less common.) \indexc{setRefClass()}
 
 ```{r}
 Account <- setRefClass("Account")
@@ -666,8 +666,8 @@ If you've programmed in a mainstream OO language, RC will seem very natural. But
 ## Quiz answers {#oo-answers}
 
 1.  To determine the OO system of an object, you use a process of elimination.
-    If `!is.object(x)`, it's a base object. If `!isS4(x)`, it's S3. If 
-    `!is(x, "refClass")`, it's S4; otherwise it's RC.
+    If `!is.object(x)`, it is a base object. If `!isS4(x)`, it is S3. If 
+    `!is(x, "refClass")`, it is S4; otherwise it is RC.
     
 1.  Use `typeof()` to determine the base class of an object.
 


### PR DESCRIPTION
I suggest to replace all abbreviated forms of the verb be, i.e., " 's ", by the corresponding full form, namely " is ". I believe it would make this documentation more professional and slightly clearer.