### PR TITLE
custom_stop, not customStop

### DIFF
--- a/Exceptions-Debugging.rmd
+++ b/Exceptions-Debugging.rmd
@@ -655,7 +655,7 @@ tryCatch(
 Note that when using `tryCatch()` with multiple handlers and custom classes, the first handler to match any class in the signal's class hierarchy is called, not the best match. For this reason, you need to make sure to put the most specific handlers first:
 
 ```{r}
-tryCatch(customStop("my_error", "!"),
+tryCatch(custom_stop("my_error", "!"),
   error = function(c) "error",
   my_error = function(c) "my_error"
 )


### PR DESCRIPTION
A typo in the section on custom conditions. Accidentally it produced the correct result in the output.
