### PR TITLE
Not the same results from R and the book

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -549,7 +549,7 @@ f(stop("This is an error!"))
 ```
 
 This is important when creating closures with `lapply()` or a loop:
-
+ 
 ```{r}
 add <- function(x) {
   function(y) x + y


### PR DESCRIPTION
I added a space in the empty line 552 to be able to propose this "change" or otherwise report this bug/issue:

When I run the following code in R:

add <- function(x) {
  function(y) x + y
}
adders <- lapply(1:10, add)
adders[[1]](10)
adders[[10]](10)

I get:

> adders[[1]](10)
[1] 20
> adders[[10]](10)
[1] 20

But the output in the book online is:

adders[[1]](10)
#> [1] 11
adders[[10]](10)
#> [1] 20

I assume the 11 should be a 20 to demonstrate the difference of using force.