### PR TITLE
Minor formatting fixes on Amazon book link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,7 +39,7 @@
         </div>
 
         <div class="well">
-          Want a physical copy of this material? <a href="http://amzn.com/1466586966?tag=devtools-20">Buy a book from amazon!</a>.
+          Want a physical copy of this material? <a href="http://amzn.com/1466586966?tag=devtools-20">Buy a book from Amazon!</a>
         </div>
 
         <h4>Contents</h4>


### PR DESCRIPTION
Capitalize Amazon for consistency, remove trailing period.