### PR TITLE
Spelling/grammar mistake

### DIFF
--- a/Environments.rmd
+++ b/Environments.rmd
@@ -409,7 +409,7 @@ The enclosing environment belongs to the function, and never changes, even if th
 
 The distinction between the binding environment and the enclosing environment is important for package namespaces. Package namespaces keep packages independent. For example, if package A uses the base `mean()` function, what happens if package B creates its own `mean()` function? Namespaces ensure that package A continues to use the base `mean()` function, and that package A is not affected by package B (unless explicitly asked for). \index{namespaces}
 
-Namespaces are implemented using environments, taking advantage of the fact that functions don't have to live in their enclosing environments. For example, take the base function `sd()`. It's binding and enclosing environments are different:
+Namespaces are implemented using environments, taking advantage of the fact that functions don't have to live in their enclosing environments. For example, take the base function `sd()`. Its binding and enclosing environments are different:
 
 ```{r, eval = FALSE}
 environment(sd)


### PR DESCRIPTION
"It's" should be "Its" as it is a possessive pronoun referred to the aforementioned function sd()

I assign the copyright of this contribution to Hadley Wickham
