### PR TITLE
Use getMethod to avoid S4 method dispatch

### DIFF
--- a/Profiling.rmd
+++ b/Profiling.rmd
@@ -326,7 +326,7 @@ Sometimes you can make a function faster by avoiding method dispatch. As we saw 
 
 * For S3, you can do this by calling `generic.class()` instead of `generic()`. 
 
-* For S4, you can do this by using `findMethod()` to find the method, saving 
+* For S4, you can do this by using `getMethod()` to find the method, saving 
   it to a variable, and then calling that function. 
 
 For example, calling `mean.default()` quite a bit faster than calling `mean()` for small vectors:


### PR DESCRIPTION
Hello Hadley,

I think in this case it should be `getMethod` instead of `findMethod` to avoid S4 method dispatch. `findMethod` returns the environment (as a list) that contains the method and not the method itself, and I don't know how to get the method from the environment. Please clarify.

Cheers,
Alex
