### PR TITLE
Changed travis.yml to prevent build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - pandoc --version
 
   # Install jekyll
-  - travis_retry gem install jekyll mime-types
+  - travis_retry gem install jekyll -v 2.5.3 mime-types
 
   # Install R packages
   - ./travis-tool.sh r_binary_install rcpp rjsonio knitr ggplot2 png

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - pandoc --version
 
   # Install jekyll
-  - travis_retry gem install jekyll:2.5.3 mime-types
+  - travis_retry gem install jekyll:2.5.3 mime-types:2.6.2
 
   # Install R packages
   - ./travis-tool.sh r_binary_install rcpp rjsonio knitr ggplot2 png

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - pandoc --version
 
   # Install jekyll
-  - travis_retry gem install jekyll -v 2.5.3 mime-types
+  - travis_retry gem install jekyll:2.5.3 mime-types
 
   # Install R packages
   - ./travis-tool.sh r_binary_install rcpp rjsonio knitr ggplot2 png


### PR DESCRIPTION
At the moment, all travis builds are failing because the latest versions of the jekyll and mime-types require a version of ruby newer than that on the server. I've specified versions of these packages that depend on the old version or ruby.
