### PR TITLE
Profiling.Rmd: Updating typos to s5q6

### DIFF
--- a/Profiling.rmd
+++ b/Profiling.rmd
@@ -539,7 +539,7 @@ microbenchmark(
     df <- data.frame(a = rnorm(n), b = rnorm(n))
 
     cor_df <- function(q, n) {
-      i <- sample(seq(n), n * 0.01)
+      i <- sample(seq(n), n * 0.01, replace = TRUE)
       cor(q[i, , drop = FALSE])[2,1]
     }
     ```

--- a/Profiling.rmd
+++ b/Profiling.rmd
@@ -539,7 +539,7 @@ microbenchmark(
     df <- data.frame(a = rnorm(n), b = rnorm(n))
 
     cor_df <- function(q, n) {
-      i <- sample(seq(n), n * 0.01, replace = TRUE)
+      i <- sample(seq(n), n, replace = TRUE)
       cor(q[i, , drop = FALSE])[2,1]
     }
     ```

--- a/Profiling.rmd
+++ b/Profiling.rmd
@@ -538,7 +538,7 @@ microbenchmark(
     n <- 1e6
     df <- data.frame(a = rnorm(n), b = rnorm(n))
 
-    cor_df <- function(i) {
+    cor_df <- function(q, n) {
       i <- sample(seq(n), n * 0.01)
       cor(q[i, , drop = FALSE])[2,1]
     }


### PR DESCRIPTION
The function should have both the data frame and number of observations passed as arguments. Currently, it has neither.

Same as #706, except this request maintains `q` as an argument and removes the global dependency on `n`.
