### PR TITLE
Append effect of which() that ignores NAs in the logical vector

### DIFF
--- a/Subsetting.rmd
+++ b/Subsetting.rmd
@@ -596,7 +596,7 @@ df <- data.frame(x = 1:3, y = 3:1, z = letters[1:3])
 df[c("x", "y")]
 ```
 
-If you know the columns you don't want, use set operations to work out which colums to keep:
+If you know the columns you don't want, use set operations to work out which columns to keep:
 
 ```{r}
 df[setdiff(names(df), "z")]
@@ -673,7 +673,7 @@ xor(x1, y1)
 setdiff(union(x2, y2), intersect(x2, y2))
 ```
 
-When first learning subsetting, a common mistake is to use `x[which(y)]` instead of `x[y]`.  Here the `which()` achieves nothing: it switches from logical to integer subsetting but the result will be exactly the same. Also beware that `x[-which(y)]` is __not__ equivalent to `x[!y]`: if `y` is all FALSE, `which(y)` will be `integer(0)` and `-integer(0)` is still `integer(0)`, so you'll get no values, instead of all values. In general, avoid switching from logical to integer subsetting unless you want, for example, the first or last `TRUE` value.
+When first learning subsetting, a common mistake is to use `x[which(y)]` instead of `x[y]`.  Here the `which()` achieves nothing: it switches from logical to integer subsetting but the result will be exactly the same when `y` does not have any `NA`. In the case that `y` can contain any `NA`, `which()` can be used to ignore `NA` in `y`. Also beware that `x[-which(y)]` is __not__ equivalent to `x[!y]`: if `y` is all FALSE, `which(y)` will be `integer(0)` and `-integer(0)` is still `integer(0)`, so you'll get no values, instead of all values. In general, avoid switching from logical to integer subsetting unless you want, for example, the first or last `TRUE` value.
 
 ### Exercises
 


### PR DESCRIPTION
- Fix a typo in line 599 (columns)
- which() ignores NAs in the logical vector, while ‘[‘ does not ignore
  it. I appended a sentence of this difference.
