### PR TITLE
Update Functions.rmd

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -562,11 +562,11 @@ adders[[10]](10)
 `x` is lazily evaluated the first time that you call one of the adder functions. At this point, the loop is complete and the final value of `x` is 10.  Therefore all of the adder functions will add 10 on to their input, probably not what you wanted!  Manually forcing evaluation fixes the problem:
 
 ```{r}
-add <- function(x) {
+add2 <- function(x) {
   force(x)
   function(y) x + y
 }
-adders2 <- lapply(1:10, add)
+adders2 <- lapply(1:10, add2)
 adders2[[1]](10)
 adders2[[10]](10)
 ```
@@ -574,7 +574,7 @@ adders2[[10]](10)
 This code is exactly equivalent to
 
 ```{r}
-add <- function(x) {
+add2 <- function(x) {
   x
   function(y) x + y
 }


### PR DESCRIPTION
Currently the lazy evaluation examples using adders and adders2 appear in your text to give identical output (which they don't when I run the code on my own; there, I get the expected wrong answers for adders). My best guess is that it's because you used the name add() for both function definitions, so I propose changing the second function name. I can't explain why the later definition gets applied in earlier code, though (which makes me feel like I'm failing a pop quiz on this material).

In case it is relevant: I assign the copyright of this contribution to Hadley Wickham.
