### PR TITLE
Update Functional Programming.Rmd

### DIFF
--- a/Functional-programming.rmd
+++ b/Functional-programming.rmd
@@ -705,11 +705,11 @@ It turns out that the midpoint, trapezoid, Simpson, and Boole rules are all exam
 
 ```{r}
 newton_cotes <- function(coef, open = FALSE) {
-  n <- length(coef) + open
+  n <- length(coef) -1 + open
 
   function(f, a, b) {
     pos <- function(i) a + i * (b - a) / n
-    points <- pos(seq.int(0, length(coef) - 1))
+    points <- pos(seq.int(0, ifelse(open, n-1, n)))
 
     (b - a) / sum(coef) * sum(f(points) * coef)
   }


### PR DESCRIPTION
lines 708 added a -1
line 712 changed length(coef)-1 to ifelse(open, n, n-1)

Reason: the way the function is written it never evaluates at the last point b. I tested on newton_cotes(7,32,12,32,7)
