### PR TITLE
Wrong output (6 instead of 7)

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -791,7 +791,7 @@ address(x)
 
 Built-in functions that are implemented using `.Primitive()` will modify in place: \index{primitive functions}
 
-```{r, eval = FALSE}
+```{r, eval = TRUE, results = "hide"}
 x <- 1:10
 address(x)
 #> [1] "0x103945110"


### PR DESCRIPTION
If the code snippet is not evaluated, than x remains the same, as in 789 line.
In other words, the second element remains 6, because line 799 is not evaluated.
Therefore, printing x in line 814 will return "10 6 3 ..." instead of assumed "10 7 3 ..."
