### PR TITLE
Lazy evaluation example is not working as expected

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -548,13 +548,16 @@ f <- function(x) {
 f(stop("This is an error!"))
 ```
 
-This is important when creating closures with `lapply()` or a loop:
+This is important when creating closures with a loop:
 
 ```{r}
 add <- function(x) {
   function(y) x + y
 }
-adders <- lapply(1:10, add)
+adders <- list()
+for (i in 1:10) {
+  adders[[i]] <- add(i)
+}
 adders[[1]](10)
 adders[[10]](10)
 ```
@@ -566,7 +569,10 @@ add <- function(x) {
   force(x)
   function(y) x + y
 }
-adders2 <- lapply(1:10, add)
+adders2 <- list()
+for (i in 1:10) {
+  adders2[[i]] <- add(i)
+}
 adders2[[1]](10)
 adders2[[10]](10)
 ```


### PR DESCRIPTION
The paragraph following the code example states that the variable x is evaluated only when the first adder function is called. The rationale is that at that point the loop is complete and the final value of x is 10, and so every adder function will return 10 plus what value is passed in. Looking at the output of the example, however, you'll notice that the result is correct, i.e., the expected value, not 10, is being added to the passed in value. It looks like the lapply function is doing the right thing and somehow forcing the evaluation of the x variable. To accomplish the stated effect, however, you could just use a simple for loop instead, and so I've updated the example to use a for loop. This will make the code "work" with the explanation that follows.

I hope this PR helps, and as always, I assign the copyright of this contribution to Hadley Wickham.
