### PR TITLE
replace logical T and F with TRUE and FALSE in Subsetting.rmd

### DIFF
--- a/Style.rmd
+++ b/Style.rmd
@@ -203,4 +203,4 @@ Use commented lines of `-` and `=` to break up your file into easily readable ch
 # Plot data ---------------------------
 ```
 
- [1]: http://google-styleguide.googlecode.com/svn/trunk/google-r-style.html
+ [1]: https://google.github.io/styleguide/Rguide.xml

--- a/Subsetting.rmd
+++ b/Subsetting.rmd
@@ -178,7 +178,7 @@ The most common way of subsetting matrices (2d) and arrays (>2d) is a simple gen
 a <- matrix(1:9, nrow = 3)
 colnames(a) <- c("A", "B", "C")
 a[1:2, ]
-a[c(T, F, T), c("B", "A")]
+a[c(TRUE, FALSE, TRUE), c("B", "A")]
 a[0, -2]
 ```
 


### PR DESCRIPTION
Replaced one character versions of TRUE and FALSE for clarity and for reasons alluded too in Style.rmd line 60 (i.e. that T and F are not reserved words).
