### PR TITLE
Update abs() function

### DIFF
--- a/Rcpp.rmd
+++ b/Rcpp.rmd
@@ -771,7 +771,7 @@ A number of helpful functions provide a "view" of a vector: `head()`, `tail()`, 
 
 Finally, there's a grab bag of sugar functions that mimic frequently used R functions:
 
-* Math functions: `abs()`, `acos()`, `asin()`, `atan()`, `beta()`, `ceil()`,
+* Math functions: `std::abs()`, `acos()`, `asin()`, `atan()`, `beta()`, `ceil()`,
  `ceiling()`, `choose()`, `cos()`, `cosh()`, `digamma()`, `exp()`, `expm1()`, 
  `factorial()`, `floor()`, `gamma()`, `lbeta()`, `lchoose()`, `lfactorial()`, 
  `lgamma()`, `log()`, `log10()`, `log1p()`, `pentagamma()`, `psigamma()`,


### PR DESCRIPTION
The function abs() listed in the "Other useful functions" section caused errors.  After some searching, I discovered this post: https://github.com/RcppCore/Rcpp/issues/167, identifying abs() as the old C function.

I assign the copyright of this contribution to Hadley Wickham.
