### PR TITLE
Modify example based on changes to apply.

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -548,13 +548,16 @@ f <- function(x) {
 f(stop("This is an error!"))
 ```
 
-This is important when creating closures with `lapply()` or a loop:
+This is important when creating closures with loops:
 
 ```{r}
 add <- function(x) {
   function(y) x + y
 }
-adders <- lapply(1:10, add)
+adders <- list()
+for (i in 1:10) {
+  adders[[i]] <- add(i)
+}
 adders[[1]](10)
 adders[[10]](10)
 ```
@@ -566,7 +569,10 @@ add <- function(x) {
   force(x)
   function(y) x + y
 }
-adders2 <- lapply(1:10, add)
+adders2 <- list()
+for (i in 1:10) {
+  adders2[[i]] <- add(i)
+}
 adders2[[1]](10)
 adders2[[10]](10)
 ```


### PR DESCRIPTION
The apply() functions no longer (https://stat.ethz.ch/pipermail/r-announce/2015/000583.html) does lazy evaluation in the way that the text suggests, leading two of the code snippets to produce the same output. However, the unintended consequences of lazy evaluation still apply to for loops, so I modified the examples to consider for loops instead of lapply.
