### PR TITLE
Add 2 (missing?) ways to access a single value

### DIFF
--- a/Performance.rmd
+++ b/Performance.rmd
@@ -269,8 +269,10 @@ The following microbenchmark shows seven ways to access a single value (the numb
 microbenchmark(
   "[32, 11]"      = mtcars[32, 11],
   "$carb[32]"     = mtcars$carb[32],
+  "$carb[[32]]"   = mtcars$carb[[32]],
   "[[c(11, 32)]]" = mtcars[[c(11, 32)]],
   "[[11]][32]"    = mtcars[[11]][32],
+  ".subset"       = .subset(mtcars, 11)[32],
   ".subset2"      = .subset2(mtcars, 11)[32]
 )
 ```


### PR DESCRIPTION
The existing text says it compares seven ways, but there are only five ways. I was interested in performance of .subset and $+[[, so I added these. I was surprised that $carb[[32]] was no faster than $carb[32]. A very interesting case!

I assign the copyright of this contribution to Hadley Wickham.
