### PR TITLE
Remove parens from attribute names

### DIFF
--- a/Data-structures.rmd
+++ b/Data-structures.rmd
@@ -267,7 +267,7 @@ You can create a new vector without names using `unname(x)`, or remove names in 
 
 ### Factors
 
-One important use of attributes is to define factors. A factor is a vector that can contain only predefined values, and is used to store categorical data. Factors are built on top of integer vectors using two attributes: the `class()`, "factor", which makes them behave differently from regular integer vectors, and the `levels()`, which defines the set of allowed values. \index{factors|(}
+One important use of attributes is to define factors. A factor is a vector that can contain only predefined values, and is used to store categorical data. Factors are built on top of integer vectors using two attributes: the `class`, "factor", which makes them behave differently from regular integer vectors, and the `levels`, which defines the set of allowed values. \index{factors|(}
 
 ```{r}
 x <- factor(c("a", "b", "b", "a"))
@@ -346,7 +346,7 @@ While factors look (and often behave) like character vectors, they are actually 
 
 ## Matrices and arrays {#matrices-and-arrays}
 
-Adding a `dim()` attribute to an atomic vector allows it to behave like a multi-dimensional __array__. A special case of the array is the __matrix__, which has two dimensions. Matrices are used commonly as part of the mathematical machinery of statistics. Arrays are much rarer, but worth being aware of. \index{arrays|(} \index{matrices|see{arrays}}
+Adding a `dim` attribute to an atomic vector allows it to behave like a multi-dimensional __array__. A special case of the array is the __matrix__, which has two dimensions. Matrices are used commonly as part of the mathematical machinery of statistics. Arrays are much rarer, but worth being aware of. \index{arrays|(} \index{matrices|see{arrays}}
 
 Matrices and arrays are created with `matrix()` and `array()`, or by using the assignment form of `dim()`:
 


### PR DESCRIPTION
The text is talking about attribute names, not names of accessor functions.
