### PR TITLE
Wrong output in code chunk due to eval = FALSE

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -791,7 +791,7 @@ address(x)
 
 Built-in functions that are implemented using `.Primitive()` will modify in place: \index{primitive functions}
 
-```{r, eval = FALSE}
+```{r, eval = TRUE, results='hide'}
 x <- 1:10
 address(x)
 #> [1] "0x103945110"


### PR DESCRIPTION
If eval = FALSE, then in the next code chunk the second element of the vector `x` will be 6, instead of 7. It must be 7, because we have changed this value by `x[2] <- 7L`.
