### PR TITLE
Incomplete example of lazy evaluation

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -555,7 +555,7 @@ add <- function(x) {
   function(y) x + y
 }
 adders <- lapply(1:10, add)
-adders[[1]](10)
+adders[[1]](10) # actually returns 11
 adders[[10]](10)
 ```
 


### PR DESCRIPTION
In the example the function call returns 11, which is supposed to be 20 by the text of the book.
Probably, this is a recent change in R in the lazy evaluation.
