### PR TITLE
Incomplete example of lazy evaluation

### DIFF
--- a/Function-operators.rmd
+++ b/Function-operators.rmd
@@ -291,7 +291,7 @@ Unfortunately there's a problem with this implementation because function argume
 funs <- list(mean = mean, sum = sum)
 funs_m <- lapply(funs, delay_by, delay = 0.1)
 
-funs_m$mean(1:10)
+funs_m$mean(1:10) # the function returns 5.5
 ```
 
 We can avoid that problem by explicitly forcing the evaluation of `f()`:


### PR DESCRIPTION
The function returns 5.5 instead of "expected" 55. Probably, lapply use a black magic to force the argument by itself.
