### PR TITLE
failwith does not print an error message

### DIFF
--- a/Function-operators.rmd
+++ b/Function-operators.rmd
@@ -407,7 +407,7 @@ failwith <- function(default = NULL, f, quiet = FALSE) {
   }
 }
 log("a")
-failwith(NA, log)("a")
+failwith(NA, log)("a") # does not print an error message
 failwith(NA, log, quiet = TRUE)("a")
 ```
 


### PR DESCRIPTION
failwith function with default parameter quite = FALSE does not print the error message.
This is probably due to a particularity of Rmarkdown ( try(log("a")) also won't print anything in Rmarkdown)
