### PR TITLE
`length` of a matrix is not the same as its number of rows.

### DIFF
--- a/Data-structures.rmd
+++ b/Data-structures.rmd
@@ -366,8 +366,8 @@ c
 
 `length()` and `names()` have high-dimensional generalisations:
 
-* `length()` generalises to `nrow()` and `ncol()` for matrices, and `dim()`
-  for arrays. \indexc{nrow()} \indexc{ncol()} \indexc{dim()}
+* `length()` generalises to `nrow()` times `ncol()` for matrices, and
+  `dim()` for arrays. \indexc{nrow()} \indexc{ncol()} \indexc{dim()}
 
 * `names()` generalises to `rownames()` and `colnames()` for matrices, and
   `dimnames()`, a list of character vectors, for arrays. \indexc{rownames()}


### PR DESCRIPTION
```
> length(m) == nrow(m) * ncol(m)
[1] TRUE
> length(m) == nrow(m) || length(m) == ncol(m)
[1] FALSE
```
