### PR TITLE
Some precisions on tryCatch() vs withCallingHandlers()

### DIFF
--- a/Exceptions-Debugging.rmd
+++ b/Exceptions-Debugging.rmd
@@ -399,8 +399,13 @@ In R, there are three tools for handling conditions (including errors) programma
 * `tryCatch()` lets you specify __handler__ functions that control what
   happens when a condition is signalled.
 
-* `withCallingHandlers()` is a variant of `tryCatch()` that runs its handlers
-  in a different context. It's rarely needed, but is useful to be aware of.
+* `withCallingHandlers()` is a variant of `tryCatch()` that establishes local
+  handlers, whereas `tryCatch()` registers exiting handlers. Local handlers are
+  called in the same context as where the condition is signalled, without
+  interrupting the execution of the function. When a exiting handler from
+  `tryCatch()` is called, the execution of the function is interrupted and the
+  handler is called. `withCallingHandlers()` is rarely needed, but is useful to
+  be aware of.
 
 The following sections describe these tools in more detail.
 
@@ -551,16 +556,7 @@ while(i < 3) {
 
 ### `withCallingHandlers()`
 
-An alternative to `tryCatch()` is `withCallingHandlers()`. There are two main differences between these functions: \indexc{withCallingHandlers()}
-
-* The return value of `tryCatch()` handlers is returned by `tryCatch()`,
-  whereas the return value of `withCallingHandlers()` handlers is ignored:
-
-    ```{r, error = TRUE}
-    f <- function() stop("!")
-    tryCatch(f(), error = function(e) 1)
-    withCallingHandlers(f(), error = function(e) 1)
-    ```
+An alternative to `tryCatch()` is `withCallingHandlers()`. The difference between the two is that the former establishes *exiting* handlers while the latter registers *local* handlers. Here the main differences between the two kind of handlers: \indexc{withCallingHandlers()}
 
 * The handlers in `withCallingHandlers()` are called in the context of the
   call that generated the condition whereas the handlers in `tryCatch()` are
@@ -593,6 +589,39 @@ An alternative to `tryCatch()` is `withCallingHandlers()`. There are two main di
 
     This also affects the order in which `on.exit()` is called.
 
+* A related difference is that with `tryCatch()`, the flow of execution is
+  interrupted when a handler is called, while with `withCallingHandlers()`,
+  execution continues normally when the handler returns. This includes the
+  signalling function which continues its course after having called the handler
+  (e.g., `stop()` will continue stopping the program and `message()` or
+  `warning()` will continue signalling a message/warning). This is why it is
+  often better to handle a message with `withCallingHandlers()` rather than
+  `tryCatch()`, since the latter will stop the program:
+
+    ```{r, message = TRUE}
+    message_handler <- function(c) cat("Caught a message!\n")
+
+    tryCatch(message = message_handler, {
+      message("Someone there?")
+      message("Why, yes!")
+    })
+
+    withCallingHandlers(message = message_handler, {
+      message("Someone there?")
+      message("Why, yes!")
+    })
+    ```
+
+* The return value of a handler is returned by `tryCatch()`, whereas it is
+  ignored with `withCallingHandlers()`:
+
+    ```{r, message = TRUE}
+    f <- function() message("!")
+    tryCatch(f(), message = function(m) 1)
+    withCallingHandlers(f(), message = function(m) 1)
+    ```
+
+
 These subtle differences are rarely useful, except when you're trying to capture exactly what went wrong and pass it on to another function. For most purposes, you should never need to use `withCallingHandlers()`.
 
 ### Custom signal classes
@@ -601,7 +630,7 @@ One of the challenges of error handling in R is that most functions just call `s
 
 R has a little known and little used feature to solve this problem. Conditions are S3 classes, so you can define your own classes if you want to distinguish different types of error. Each condition signalling function, `stop()`, `warning()`, and `message()`, can be given either a list of strings, or a custom S3 condition object. Custom condition objects are not used very often, but are very useful because they make it possible for the user to respond to different errors in different ways. For example, "expected" errors (like a model failing to converge for some input datasets) can be silently ignored, while unexpected errors (like no disk space available) can be propagated to the user.
 
-R doesn't come with a built-in constructor function for conditions, but we can easily add one. Conditions must contain `message` and `call` components, and may contain other useful components. When creating a new condition, it should always inherit from `condition` and one of `error`, `warning`, or `message`.
+R doesn't come with a built-in constructor function for conditions, but we can easily add one. Conditions must contain `message` and `call` components, and may contain other useful components. When creating a new condition, it should always inherit from `condition` and should in most cases inherit from one of `error`, `warning`, or `message`.
 
 ```{r}
 condition <- function(subclass, message, call = sys.call(-1), ...) {


### PR DESCRIPTION
Most importantly the fact that control flow continues normally after a non-exiting handler is called.