### PR TITLE
Change markdown code for the in_dir function

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -974,7 +974,8 @@ As well as returning a value, functions can set up other triggers to occur when 
 
 ```{r}
 in_dir <- function(dir, code) {
-  old <- setwd(dir)
+  old <- getwd()
+  setwd(dir)
   on.exit(setwd(old))
 
   force(code)


### PR DESCRIPTION
Function was not saving the current working directory as a variable for the on.exit function to reset the directory back to.