### PR TITLE
Fix assignment typo

### DIFF
--- a/Environments.Rmd
+++ b/Environments.Rmd
@@ -69,7 +69,7 @@ knitr::include_graphics("diagrams/environments.png/bindings.png")
 The objects don't live in the environment so multiple names can point to the same object:
 
 ```{r}
-e$b <- e$d
+e$a <- e$d
 ```
 ```{r, echo = FALSE}
 knitr::include_graphics("diagrams/environments.png/multiple-names.png")
@@ -78,7 +78,7 @@ knitr::include_graphics("diagrams/environments.png/multiple-names.png")
 Confusingly they can also point to different objects that have the same value:
 
 ```{r}
-e$b <- 1:3
+e$a <- 1:3
 ```
 ```{r, echo = FALSE}
 knitr::include_graphics("diagrams/environments.png/copies.png")


### PR DESCRIPTION
Hi,

The current assignments do not match the diagrams. This patch changes two assignments in order to match them.

Kind regards,
Romero Morais