### PR TITLE
Subassignments when RHS length is multiple of LHS

### DIFF
--- a/Subsetting.Rmd
+++ b/Subsetting.Rmd
@@ -429,8 +429,10 @@ x <- 1:5
 x[c(1, 2)] <- 2:3
 x
 
-# The length of the LHS needs to match the RHS
+# The length of the LHS needs to be a multiple of the RHS
 x[-1] <- 4:1
+x
+x[-1] <- 1:2
 x
 
 # Note that there's no checking for duplicate indices


### PR DESCRIPTION
It is also possible to perform a subassignment when the length of the
LHS items is a multiple of the RHS items.

I assign the copyright of this contribution to Hadley Wickham