### PR TITLE
Use dbplyr not dplyr

### DIFF
--- a/dsl.Rmd
+++ b/dsl.Rmd
@@ -1,15 +1,15 @@
 # Domain specific languages {#dsl}
 
 ```{r setup, include = FALSE}
-library(dplyr) # to supress startup messages below
+library(dbplyr) # to supress startup messages below
 ```
 
 The combination of first class environments, lexical scoping, non-standard evaluation, and metaprogramming gives us a powerful toolkit for creating embedded domain specific languages (DSLs) in R. Embedded DSLs take advantage of a host language's parsing and execution framework, but adjust the semantics to make them more suitable for a specific task. DSLs are a very large topic, and this chapter will only scratch the surface, focussing on important implementation techniques rather than on how you might come up with the language in the first place. If you're interested in learning more, I highly recommend [_Domain Specific Languages_](http://amzn.com/0321712943?tag=devtools-20) by Martin Fowler. It discusses many options for creating a DSL and provides many examples of different languages. \index{domain specific languages}
 
-R's most popular DSL is the formula specification, which provides a succinct way of describing the relationship between predictors and the response in a model. Other examples include ggplot2 (for visualisation) and plyr (for data manipulation). Another package that makes extensive use of these ideas is dplyr, which provides `translate_sql()` to convert R expressions into SQL:
+R's most popular DSL is the formula specification, which provides a succinct way of describing the relationship between predictors and the response in a model. Other examples include ggplot2 (for visualisation) and plyr (for data manipulation). Another package that makes extensive use of these ideas is dbplyr, which provides `translate_sql()` to convert R expressions into SQL:
 
 ```{r}
-library(dplyr)
+library(dbplyr)
 translate_sql(sin(x) + tan(y))
 translate_sql(x < 5 & !(y >= 5))
 translate_sql(first %like% "Had*")
@@ -617,7 +617,7 @@ to_math(f(a * b))
     to an environment. Write a function that automates this task, and then rewrite
     `latex_env()`.
 
-1.  Study the source code for `dplyr`. An important part of its structure is
+1.  Study the source code for `dbplyr`. An important part of its structure is
     `partial_eval()` which helps manage expressions when some of the
     components refer to variables in the database while others refer to local R
     objects. Note that you could use very similar ideas if you needed to 


### PR DESCRIPTION
Having seen the travis-cl fail the build check, I'm wondering why it was able to build the book using `dplyr`, rather than `dbplyr`.

Why is travic-cl able to find the function `translate_sql()`, even though it's not part of the `dplyr` package?

Thanks in advance if you're able to remedy my confusion.