### PR TITLE
correct newton_cotes function

### DIFF
--- a/Functional-programming.Rmd
+++ b/Functional-programming.Rmd
@@ -699,12 +699,11 @@ It turns out that the midpoint, trapezoid, Simpson, and Boole rules are all exam
 
 ```{r}
 newton_cotes <- function(coef, open = FALSE) {
-  n <- length(coef) + open
-
+  degree <- length(coef) +2*open - 1
+  
   function(f, a, b) {
-    pos <- function(i) a + i * (b - a) / n
-    points <- pos(seq.int(0, length(coef) - 1))
-
+    pos <- function(i) a + i * (b - a) / degree
+    points <- pos(seq.int(open, degree - open))
     (b - a) / sum(coef) * sum(f(points) * coef)
   }
 }


### PR DESCRIPTION
You can confirm this by testing:
boole(sin,0,pi)==newton_cotes(c(7, 32, 12, 32, 7))(sin,0,pi)
where boole is your manually defined function and newton_cotes is your original function.

I assign the copyright of this contribution to Hadley Wickham” - I need this so I can publish the printed book.