### PR TITLE
S4: Fix typo

### DIFF
--- a/S4.Rmd
+++ b/S4.Rmd
@@ -308,7 +308,7 @@ roger <- new("Employee", name = "Roger", age = 36, boss = mary)
 as(mary, "Person")
 ```
 
-Note that the opposite coercsion (from person to employee) doesn't work.
+Note that the opposite coercion (from person to employee) doesn't work.
 
 ```{r, error = TRUE}
 as(mary, "Employee")


### PR DESCRIPTION
Behold, another typo. Along the way I noticed both "initialise" and "initialize" and wanted to suggest going with "initialize" as that's the name of the generic function.