### PR TITLE
Make na_value consistent

### DIFF
--- a/Functional-programming.Rmd
+++ b/Functional-programming.Rmd
@@ -167,8 +167,8 @@ begin_sidebar("Extra argument")
 In this case, you could argue that we should just add another argument:
 
 ```{r}
-fix_missing <- function(x, na.value) {
-  x[x == na.value] <- NA
+fix_missing <- function(x, na_value) {
+  x[x == na_value] <- NA
   x
 }
 ```


### PR DESCRIPTION
In the code block right before this one `na_value` is used, but now `na.value`. However, it seems they are indicating the same so changing the writing is confusing to me.