### PR TITLE
Re-order function types to match text

### DIFF
--- a/base-types.Rmd
+++ b/base-types.Rmd
@@ -64,9 +64,8 @@ In total, there are 25 different base types. They are listed below, loosely grou
     
     ```{r}
     typeof(mean)
-    typeof(sum)
     typeof(`[`)
-    
+    typeof(sum)    
     typeof(globalenv())
     ```
     


### PR DESCRIPTION
So that the order of the function types in the code chunk is the same as in the above description

I assign the copyright of this contribution to Hadley Wickham