### PR TITLE
I have sent an email to Hadely on this.  The problem is that I don't …

### DIFF
--- a/Functions.Rmd
+++ b/Functions.Rmd
@@ -552,7 +552,10 @@ This is important when creating closures with `lapply()` or a loop:
 add <- function(x) {
   function(y) x + y
 }
-adders <- lapply(1:10, add)
+adders <- list()
+for (i in 1:10) {
+  adders[[i]] <- add(i)
+}
 adders[[1]](10)
 adders[[10]](10)
 ```
@@ -564,7 +567,10 @@ add <- function(x) {
   force(x)
   function(y) x + y
 }
-adders2 <- lapply(1:10, add)
+adders2 <- list()
+for (i in 1:10) {
+  adders2[[i]] <- add(i)
+}
 adders2[[1]](10)
 adders2[[10]](10)
 ```


### PR DESCRIPTION
…think that the lapply loop creates the condition of every function in the `adders` list  having a common x value to add to.  I think you have to explicitly loop with the variable i to get the desired behavior of a common term for all of the adder functions.

This pull request just replaces the `lapply()` call with an explicit loop, and the results I believe are the results alluded to in the commentary.