### PR TITLE
List + [ + NULL = list(), not list(NULL)

### DIFF
--- a/Subsetting.Rmd
+++ b/Subsetting.Rmd
@@ -389,7 +389,7 @@ The following table summarises the results of subsetting atomic vectors and list
 |----------|-------------|-------------|---------------|
 | `[`      | OOB         | `NA`        | `list(NULL)`  |
 | `[`      | `NA_real_`  | `NA`        | `list(NULL)`  |
-| `[`      | `NULL`      | `x[0]`      | `list(NULL)`  |
+| `[`      | `NULL`      | `x[0]`      | `list()`  |
 | `[[`     | OOB         | Error       | Error         |
 | `[[`     | `NA_real_`  | Error       | `NULL`        |
 | `[[`     | `NULL`      | Error       | Error         |


### PR DESCRIPTION
The subsetting section's table says that subsetting a list (with `[`) with `NULL` returns `list(NULL)`, but it just returns `list()`.  This corrects that.
```r
as.list(1:4)[NULL]
# list()
```