### PR TITLE
Typo and Call lists could be simplified

### DIFF
--- a/Expressions.Rmd
+++ b/Expressions.Rmd
@@ -189,7 +189,7 @@ The set of rules used to go from a sequence of tokens (like `x`, `y`, `+`) to a 
 
 ### Operator precedence and associativity
 
-The AST has to resolve two sources of ambiguity when parsing infix operators. First, what does `1 + 2 * 3` yield? Do you get 7 (i.e. `(1 + 2) * 3`), or 9 (i.e. `1 + (2 * 3)`).  Which of the two possible parse trees below does R use?
+The AST has to resolve two sources of ambiguity when parsing infix operators. First, what does `1 + 2 * 3` yield? Do you get 6 (i.e. `(1 + 2) * 3`), or 7 (i.e. `1 + (2 * 3)`).  Which of the two possible parse trees below does R use?
 
 ```{r, echo = FALSE, out.width = NULL}
 knitr::include_graphics("diagrams/expression-ambig-order.png", dpi = 450)
@@ -265,7 +265,7 @@ These forms are relatively rare, but it's good to be able to recognise them when
 
 ## Extracting, modifying, and creating calls {#calls}
 
-A call behaves similarly to a list. It has a `length()` and you can extract elements with  `[[`, `[`, and `$`. Like lists, calls are recursive, because a call can contain other calls. The main difference is that the first element of a call is special: it's the function that will get called. \index{calls}
+A call behaves similarly to a list. It has a `length()` and you can extract elements with  `[[`, `[`, and `$`. Like lists can contain other lists, calls contain other calls. The main difference is that the first element of a call is special: it's the function that will get called. \index{calls}
 
 Let's explore these ideas with a simple example:
 


### PR DESCRIPTION
Arithmetic error in "Operator precedence and associativity.

As is it introduces the concept of recursion which a lot of people won't be familiar with. I think the replacement text gets across the idea that a call can contain other calls without need to introduce the term recursion... which I don't think will be used elsewhere in the book.