### PR TITLE
AST lines to thin for color

### DIFF
--- a/Expressions.Rmd
+++ b/Expressions.Rmd
@@ -45,7 +45,7 @@ knitr::include_graphics("diagrams/expression-simple.png", dpi = 450)
     
 *   The leaves of the tree are either __symbols__, like `f` and `x`, or 
     __constants__ like `1` or `"y"`. Symbols have a purple border and rounded 
-    corners. Constants, which are atomic vectors of length one, have black 
+    corners. Constants, which are atomic vectors of length one, have thick black 
     borders and square corners. Strings are always surrounded in quotes so
     you can more easily distinguish from symbols --- more on that important
     difference later.


### PR DESCRIPTION
I made this as a text comment because I don't know how to "push" back a changed diagram (really new to git). It's really a change recommendation to make the diagrams more readable. As is, for all practical purposes, all the lines in the diagram are the same color. 

The lines that border the nodes are to thin. On high resolution displays like I it is very hard to distinguish the color. The lines need to be thicker, maybe make at least 12 pixels wide if you expect the color to convey information.

Also as is the lines vary in width. The box around "f" is wider than the rest. It looks like it was a screen grab instead of an export from whatever editor you are using to create the image and the "f" box was probably selected when the screen grab was done. 

All this is just IMHO of course.