### PR TITLE
Whitespace and code structure

### DIFF
--- a/Expressions.Rmd
+++ b/Expressions.Rmd
@@ -219,12 +219,18 @@ lobstr::ast((1 + 2) + 3)
 
 ### Whitespace
 
-R, in general, is not very sensitive to white space. Most white space is not signficiant and is not recorded in the AST. `x+y` yields exactly the same AST as `x +        y`. There's is only one place where whitespace is quite important:
+R is not very sensitive to whitespace. Whitespace ususally does not affect the structure of R code. `x+y` yields exactly the same AST as `x +        y`. There's is only one place where whitespace will affect the structure of the code and therefore how the AST is built:
 
 ```{r}
 lobstr::ast(y <- x)
 lobstr::ast(y < -x)
 ```
+Of course whitespace inside of a string will be included in the AST.
+
+```{r}
+lobstr::ast(y <- "a      b")
+```
+
 
 ### The function component
 


### PR DESCRIPTION
The intro makes the point that R code structured as a hierarchy. That is the key concept in this chapter. It should be used here too. 

I think it is also important to mention that whitespace in a string is retained... most readers probably have never written a parser or a grammar and given the sole example of <- may wonder why strings retain all whitespace... for example HTML does not retain all whitespace and that is something many readers would be familiar with, even fought with. 

Also it makes "usually" a more accurate quantifier... if there really was just a single exception like "x < -y" then usually wouldn't seem like the right quantifier to use.