### PR TITLE
HTML different than XML

### DIFF
--- a/DSLs.Rmd
+++ b/DSLs.Rmd
@@ -26,21 +26,25 @@ This chapter together pulls together many techniques discussed elsewhere in the 
 
 ## HTML {#html}
 
-HTML (hypertext markup language) is the language that underlies the majority of the web. It's a special case of SGML (standard generalised markup language), and it's similar but not identical to XML (extensible markup language). HTML looks like this: \index{HTML}
+HTML (Hypertext Markup Language, https://www.w3.org/html/) is the language that underlies the majority of the web. It's a special case of SGML (Standard Generalised Markup Language, https://www.w3.org/MarkUp/SGML/), and it shares an object module (Document Object Model, https://www.w3.org/DOM/) with XML (Extensible Markup Language, https://www.w3.org/XML/) but the syntax of HTML is quite different than that of XML. HTML version 5, the current version of HTML, looks like this: \index{HTML}
+
+HTML (Hypertext Markup Language, https://www.w3.org/html/) is the language invented by Sir Tim Berners-Lee to simplyfy publishing documents on the web. HTML 5 is the current version of HTML and this is an example of what it looks like:
 
 ```html
+<!DOCTYPE html >
+<title>my title</title>
 <body>
   <h1 id='first'>A heading</h1>
   <p>Some text &amp; <b>some bold text.</b></p>
-  <img src='myimg.png' width='100' height='100' />
+  <img src='myimg.png' width='100' height='100' alt="my image"/>
 </body>
 ```
 
-Even if you've never looked at HTML before, you can still see that the key component of its coding structure is tags, `<tag></tag>`. Tags can be contained inside other tags and intermingled with text. Generally, HTML ignores whitespaces (a sequence of whitespace is equivalent to a single space) so you could put the previous example on a single line and it would still display the same in a browser:
+Even if you've never looked at HTML before, you can still see that the key component of its coding structure is hierachy of tags, for example the <body> tag contains a <h1>, <p>, and <img>tag, and the <p> tag contains a <b> tag. Tags can be contained inside other tags and intermingled with text. Generally, HTML ignores whitespaces (a sequence of whitespace is equivalent to a single space) so you could put the previous example on a single line and it would still display the same in a browser:
 
 ```html
-<body><h1 id='first'>A heading</h1><p>Some text &amp; <b>some bold
-text.</b></p><img src='myimg.png' width='100' height='100' />
+<!DOCTYPE html ><title>"my title"</title><body><h1 id='first'>A heading</h1><p>Some text &amp; <b>some bold
+text.</b></p><img src='myimg.png' width='100' height='100' alt="my image"/>
 </body>
 ```
 


### PR DESCRIPTION
HTML and XML are quite different and that is deliberate by the recommendation, i.e. spec, for XML. 

Note: The book example is invalid html (for any version). An &lt;image&gt; tag must have an alt attribute and there has to be a &lt;title&gt; tag in the header.

I would remove any reference to XML, it really doesn't add to the understanding of HTML. The second paragraph I've added is an alternative for the first, but with no reference XML.

Here is an example completely valid HTML 5 that is not correct, i.e. not well formed, nor similar to XML.

&lt;!DOCTYPE html&gt;
&lt;title&gt;test&lt;/title&gt;
&lt;h1 id=first&gt;A heading&lt;/h1&gt;
&lt;p&gt;Some text & &lt;b&gt;some bold text.&lt;/b&gt;
&lt;img src=off-by-one.jpg width=100 height=100 alt="an image"/&gt;

Notice that there is no root tag at all, i.e. no &lt;body&gt; tag nor a &lt;html&gt; tag. Notice the lack of quotes on some attribute values. Notice there is no closing &lt;/p&gt; tag. 

Any HTML parser will create and AST of this page that includes html, body, etc. elements. Try this example in Chrome (or your favorite browser) and  use the developer tools to see the AST. That's how the W3C DOM says a parser should work.

Also it easy to make working example with html, just add a DOCTYPE and a <title> and alt to the example. I think that whenever possible examples should work and be correct. As is the example works but is not correct.

The comment about HTML and XML being similar isn't correct. HTML and "X"HTML are similar but for all practical purposes XHTML is deprecated (I don't know if it formally is, but in practice it shouldn't be used in new projects).

In fact HTML and XML are deliberately different. One of the explicit goals of the XML Recommendation was "Terseness of markup is not a goal." One of the reasons Berners-Lee specified a dialect of SGML that didn't need things like an <html> tag was because at the time it was almost always authored by hand.

Sorry but I done a lot of HTML and XML at the plumbing level (for Microsoft's msdn.com site) and "trivial" details of the HTML recommendation often caused havoc because no two browsers handled "out of spec" HTML the same.