### PR TITLE
Specifically point out typing saved by subset

### DIFF
--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -57,10 +57,12 @@ sample_df <- data.frame(a = 1:5, b = 5:1, c = c(5, 3, 1, 4, 1))
 subset(sample_df, a >= 4)
 # equivalent to:
 # sample_df[sample_df$a >= 4, ]
+# which repeats sample_df 2 times
 
 subset(sample_df, b == c)
 # equivalent to:
 # sample_df[sample_df$b == sample_df$c, ]
+# which repeats sample_df 3 times
 ```
 
 `subset()` is special because it implements different scoping rules: the expressions `a >= 4` or `b == c` are evaluated in the specified data frame rather than in the current or global environments. This is the essence of non-standard evaluation.


### PR DESCRIPTION
As is it shows and example without pointing out how it supports the text leading up to it.

I missed that the first example repeated sample_df twice. My first cut at the change was to remove the first example!