### PR TITLE
copy on write semantics / reference semantics are different

### DIFF
--- a/OO.Rmd
+++ b/OO.Rmd
@@ -72,8 +72,36 @@ Base R provides three OOP systems: S3, S4, and reference classes (RC):
     (You might wonder if S1 and S2 exist. They don't: S3 and S4 were named 
     according to the versions of S that they accompanied.)
 
-*   __RC__ implements encapsulated OO. RC objects are also mutable: they don't
-    use R's usual copy-on-modify semantics, but are modified in place. This 
+*   __RC__ implements encapsulated OO. RC objects have reference semantics. This means
+    that if an object, say obj1, is assigned to another variable, say obj2, then any changes
+    to obj1 will appear in obj2 and vica versa.  For example:
+
+```{r}
+# ref classes implement reference semantics
+RefVector <- setRefClass("RefVector", fields = c("values"))
+obj1 <- RefVector$new(values = 1:100)
+obj2 <- obj1
+# make change to obj2
+obj2$values[1] <- 10
+identical(obj1, obj2)
+#> [1] TRUE
+# obj1 and obj2 are identical because
+# the changes to obj2 were propagated to 
+# obj1 to maintain reference semantics
+
+#however "regular" R objects do not implement reference semantics
+v1 <- 1:10
+v2 <- v1
+identical(v1, v2)
+#> [1] TRUE
+v2[1] <- 9
+identical(v1,v2)
+#> [1] FALSE
+# v1 and v2 are no longer identical because
+# the change to v2 was not propogated to v1
+# because these objects do not support reference semantics
+```
+This 
     makes them harder to reason about, but allows them to solve problems that 
     are difficult to solve with S3 or S4.
 


### PR DESCRIPTION
As is the text doesn't give the reader a good idea of what is different between RC objects and "regular" objects.

The mention of to copy on write semantics refers to how physical memory is managed, it isn't necessarily related to how objects appear behave in application memory. So it is kind of red herring and doesn't really tell the reader how RC is different from other ways of using R. 

One way to implement reference semantics is to have references all point to the same memory location. That isn't what RC objects appear to do (see reprex below)

The mention of mutability isn't clear as to why RC is different. My guess is that most people that use R don't realize that when they make a change to an object that in the background R may be making a new copy of that object. In any case this section should show the practical impact of copy on write semantics.

As is the text is actually incorrect. "...they don't use R's usual copy-on-modify semantics" isn't true. The reprex below shows that in fact RC objects do, in fact, use copy on modify semantics just as non RC objects do... and it can impact memory usage and even time performance the same as it does with non RC objects. However in spite of the fact a modification to one of the fields of an instance of a RefClass do trigger a memory copy, they still implement reference semantics.

Note that the implementation in R works in a way that is very similar to how Microsoft's SQL Server implements persisted computed columns. A value based on a computation of other table columns is physically persisted in a new column (for better lookup time performance) If any changes are made to the columns that the computation is based on the the corresponding computed column is updated. 

```{r}
suppressPackageStartupMessages(library("pryr"))
Polygon <- setRefClass("Polygon", fields = c("sides"))
pryr::mem_used()
#> 36.1 MB
start <- Sys.time()
# make an instance of a RefClass with a billion numbers in it
# this should take up about 4GB of memory
s1 <- Polygon$new(sides = 1:1000000000)
Sys.time() - start
#> Time difference of 1.672721 secs
# it takes a number of seconds , maybe 2
# which is to be expected for big vector
pryr::mem_used()
#> 4.04 GB
# and memory size has increased by about 4GB as expected
# now assign s1 to s2
s2 <- s1
pryr::mem_used()
#> 4.04 GB
# no changes in memory usage
pryr::address(s1)
#> [1] "0x7fb070288ff8"
pryr::address(s2)
#> [1] "0x7fb070288ff8"
# and s1 and s2 have the same address
# so s1 and s2 are using the same memory
identical(s1, s2)
#> [1] TRUE
# and they have identical values, no surprise here

# make a change to s1
start <- Sys.time()
s1$sides[1] <- 2
Sys.time() - start
#> Time difference of 5.949904 secs
# it takes long time to make the change
pryr::mem_used()
#> 8.04 GB
# and 4GB is added to memory usage
# this implies that copy on write semantics are being used
pryr::address(s1)
#> [1] "0x7fb0706ce1c8"
pryr::address(s2)
#> [1] "0x7fb070288ff8"
# and s1 now has a different addresses
# due copying s1 to a new memory location, different for where s2 is 
# This exposes the problem with copy on write
# the suprising amount of time a mutation takes
# and increased memory usage
identical(s1$sides, s2$sides)
#> [1] TRUE
# yet reference semantics are maintained
# s1 and s2 have identical values
# make another change, this time to s2
start <- Sys.time()
s2$sides[3] <- 9
Sys.time() - start
#> Time difference of 4.109379 secs
# second mutation takes a lot of time
pryr::mem_used()
#> 8.04 GB
# but no change to memory usage
pryr::address(s1)
#> [1] "0x7fb0706ce1c8"
pryr::address(s2)
#> [1] "0x7fb070137640"
# this time s2 was copied to new address
identical(s1, s2)
#> [1] TRUE
# yet reference semantics are maintained
# now make another change to s2
start <- Sys.time()
s2$sides[4] <- 9
Sys.time() - start
#> Time difference of 4.071008 secs
# this mutation takes a long time too
pryr::mem_used()
#> 8.04 GB
pryr::address(s1)
#> [1] "0x7fb0706ce1c8"
pryr::address(s2)
#> [1] "0x7fb07015f3f0"
# but this time s2 has been copied again
identical(s1, s2)
#> [1] TRUE
# but reference semantics still apply
```