### PR TITLE
better (IMHO) acronym and correct (american) spelling for SGML

### DIFF
--- a/DSLs.Rmd
+++ b/DSLs.Rmd
@@ -26,7 +26,7 @@ This chapter together pulls together many techniques discussed elsewhere in the 
 
 ## HTML {#html}
 
-HTML (hypertext markup language) is the language that underlies the majority of the web. It's a special case of SGML (standard generalised markup language), and it's similar but not identical to XML (extensible markup language). HTML looks like this: \index{HTML}
+HTML (**H**yper**T**ext **M**arkup **L**anguage) is the language that underlies the majority of the web. It's a special case of SGML (**S**tandard **G**eneralized **M***arkup **L**anguage), and it's similar but not identical to XML (extensible markup language). HTML looks like this: \index{HTML}
 
 ```html
 <body>


### PR DESCRIPTION
G in SGML uses the american spelling with 'z', see references on relevant Wikipedia page