### PR TITLE
Update S4.Rmd

### DIFF
--- a/S4.Rmd
+++ b/S4.Rmd
@@ -252,7 +252,7 @@ setMethod("myGeneric", "Person", function(x) {
 })
 ```
 
-(Again `setMethod()` has other arguments, but you should never use them.)
+(Again, just like `setClass()`, `setMethod()` has other arguments, but you should never use them.)
 
 ### Show method
 


### PR DESCRIPTION
Clarification on what "Again" meant when talking about `setMethod` deprecated arguments, i.e. the implicit reference to `setClass`.