### PR TITLE
Changing `h` to `b` in composite functions

### DIFF
--- a/Functional-programming.Rmd
+++ b/Functional-programming.Rmd
@@ -626,22 +626,22 @@ Neither of these functions gives a very good approximation. To make them more ac
 ```{r, mid-trap}
 midpoint_composite <- function(f, a, b, n = 10) {
   points <- seq(a, b, length = n + 1)
-  h <- (b - a) / n
+  b <- (b - a) / n
 
   area <- 0
   for (i in seq_len(n)) {
-    area <- area + h * f((points[i] + points[i + 1]) / 2)
+    area <- area + b * f((points[i] + points[i + 1]) / 2)
   }
   area
 }
 
 trapezoid_composite <- function(f, a, b, n = 10) {
   points <- seq(a, b, length = n + 1)
-  h <- (b - a) / n
+  b <- (b - a) / n
 
   area <- 0
   for (i in seq_len(n)) {
-    area <- area + h / 2 * (f(points[i]) + f(points[i + 1]))
+    area <- area + b / 2 * (f(points[i]) + f(points[i + 1]))
   }
   area
 }


### PR DESCRIPTION
The `h` value in the `midpoint_composite` and `trapezoid_composite` functions appears to the hold the value of the base of the rectangle and trapezoid respectively. Given the name (`h`), one would assume that the variable represents the height. This change updates the variable name to better reflect what it represents in the equation.

I assign the copyright of this contribution to Hadley Wickham.