### PR TITLE
Add forward reference to "inheritance" section

### DIFF
--- a/S3.Rmd
+++ b/S3.Rmd
@@ -155,7 +155,7 @@ S3 doesn't provide a formal definition of a class, so it has no built-in way to 
 There are three rules that a constructor should follow. It should:
 
 1.  Be called `new_class_name()`.
-1.  Have one argument for the base object, and one for each attribute.
+1.  Have one argument for the base object, and one for each attribute. (More if the class can be subclassed, see [inheritance].)
 1.  Check the types of the base object and each attribute.
 
 Base R generally does not provide constructors (three exceptions are the internal `.difftime()`, `.POSIXct()`, and `.POSIXlt()`) so we'll demonstrate constructors by filling in some missing pieces in base. (If you want to use these constructors in your own code, you can use the versions exported by the S3 package, which complete a few details that we skip here in order to focus on the core issues.)


### PR DESCRIPTION
Not sure if it's necessary, there's a forward reference a few paragraphs below. A set of rules feels definitive, adding "maybes" as crossrefs or even footnotes might help accuracy at the risk of being slightly too verbose.