### PR TITLE
Fixing a simple typo

### DIFF
--- a/OO.Rmd
+++ b/OO.Rmd
@@ -37,7 +37,7 @@ This chapter will give you a rough lay of the land, and a field guide to help yo
 
 We'll begin with an info dump of vocabulary and terminology. Don't worry if it doesn't stick. We'll come back to these ideas multiple times in the subsequent chapters.
 
-Central to any OOP system are the concepts of class and method. A __class__ defines the behaviour of a set of __objects__, or instances, by describing their attributes and their relationship to other classes. The class is also used when selecting __methods__, functions that behave differently depending on the class of their input. A class defines what something _is_ and a methods describe what something can _do_.
+Central to any OOP system are the concepts of class and method. A __class__ defines the behaviour of a set of __objects__, or instances, by describing their attributes and their relationship to other classes. The class is also used when selecting __methods__, functions that behave differently depending on the class of their input. A class defines what something _is_ and methods describe what something can _do_.
 
 Classes are usually organised in a hierarchy: if a method does not exist for a child, then the parent's method is used instead. This means that a child class will __inherit__ behaviour from the parent class. Inheritance is one of the most important parts of OOP because it allows you to reduce the amount of code you have to write.
 


### PR DESCRIPTION
The phrase "...and a methods describe what something _do_" is a bit weird. It should either be singular throughout the whole statement or plural. I decided to go with the plural "methods" by simply removing the article "a" before it.

I assign the copyright of this contribution to Hadley Wickham.
