### PR TITLE
Fixing some typos in chapter 19

### DIFF
--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -8,7 +8,7 @@ library(purrr)
 
 ## Introduction
 
-Now that you understand the tree structure of R code, it's time to come back to one of the fundamental ideas that make `expr()` and `ast()` work: __quasiquotation__.  There are two pieces the quasiquotation:
+Now that you understand the tree structure of R code, it's time to come back to one of the fundamental ideas that make `expr()` and `ast()` work: __quasiquotation__.  There are two pieces to quasiquotation:
 
 * Quoting allows you to capture the AST associated with a function argument 
   without evaluating it.
@@ -20,7 +20,7 @@ This combination of these two ideas makes it easy to compose expressions that ar
 
 Quasiquotation is available in base R, but is implemented in the the rlang package. We'll begin the chapter by using rlang to dive into the details of quasiquotation. Next, we'll circle back to base R. You'll learn the closest equivalents to rlang's quoting functions, and the variety of techniques that base R uses for unquoting. We'll finish the chapter with a case study: using quasiquotation to construct calls "by hand". This is a useful technique for creating simple function operators with readable source code, and is a handy technique to work around functions (in base R and elsewhere) that don't support unquoting.
 
-The ideas presented in this chapter are rather similar to Lisp __macros__, as discussed in [Programmer's Niche: Macros in R](http://www.r-project.org/doc/Rnews/Rnews_2001-3.pdf#page=10) by Thomas Lumley. However, macros are run at compile-time, which doesn't have any meaning in R, and always return expressions. They're also somewhat like Lisp [__fexprs__](http://en.wikipedia.org/wiki/Fexpr), function where all arguments are quoted by default. These termsare useful to know when looking for related techniques in other programming languages. \index{macros} \index{fexprs}
+The ideas presented in this chapter are rather similar to Lisp __macros__, as discussed in [Programmer's Niche: Macros in R](http://www.r-project.org/doc/Rnews/Rnews_2001-3.pdf#page=10) by Thomas Lumley. However, macros are run at compile-time, which doesn't have any meaning in R, and always return expressions. They're also somewhat like Lisp [__fexprs__](http://en.wikipedia.org/wiki/Fexpr), functions where all arguments are quoted by default. These terms are useful to know when looking for related techniques in other programming languages. \index{macros} \index{fexprs}
 
 ### Motivation
 
@@ -67,7 +67,7 @@ We need some way to explicitly __unquote__ the input, to tell `cement()` to remo
 cement(Good, !!time, !!name)
 ```
 
-It's useful to compare `cement()` and `paste()` directly. `paste()` evaluates its arguments, so we need quote where needed; `cement()` quotes its arguments, so we need unquote where needed.
+It's useful to compare `cement()` and `paste()` directly. `paste()` evaluates its arguments, so we need to quote where needed; `cement()` quotes its arguments, so we need to unquote where needed.
 
 ```{r, eval = FALSE}
 paste("Good", name, time)
@@ -80,17 +80,17 @@ The idea of quasiquotation is an old one. It was first developed by a philsopher
 
 *  'net' is part of 'clarinet', but a net is not part of a clarinet.
 
-*  Boston is a city. 'Boston' is the name of a city. ``Boston'' is not the 
+*  Boston is a city. 'Boston' is the name of a city. ``Boston`` is not the 
    name of a city; it denotes the name of a city.
 
 *  An hour is longer than a minute, but 'minute' is longer than 'hour'.
 
-[^1]: You might be familiar with the name Quine from "quines", computer programs that when run return a copy of theyeah, ir own source code.
+[^1]: You might be familiar with the name Quine from "quines", computer programs that when run return a copy of their own source code.
 [^2]: In another interesting connection, John MacFarlane is the author of pandoc which is used as part of the RMarkdown toolchain to generate pdfs, ebooks, and websites like this book.
 
 It wasn't until the mid-1970s that quasiquotation entered common use in a programming language: LISP. Useful history at <http://repository.readscheme.org/ftp/papers/pepm99/bawden.pdf>. Another way of thinking about quasiquotation is that it provides a code template. You define an AST with some "holes" that get filled in using the values of other variables.
 
-We use quasiquotation to refer the specific form of unquoting used inside otherwise quoted content. In tidy evaluation it uses `!!`.  But other languages use slightly different approaches. For example, in LISP you always use `` ` `` to quasi-quote an expression (arguments never automatically quote for you), and you use `,` to unquote. In julia you use `:` to quote and `@` to unquote.
+We use quasiquotation to refer to the specific form of unquoting used inside otherwise quoted content. In tidy evaluation it uses `!!`.  But other languages use slightly different approaches. For example, in LISP you always use `` ` `` to quasi-quote an expression (arguments never automatically quote for you), and you use `,` to unquote. In julia you use `:` to quote and `@` to unquote.
 
 Quasiquotation is useful in R because it allows us to have a systematic way of distinguishing when we want to refer to the name `x` vs. the contents of the variable called `x`.
 
@@ -120,9 +120,9 @@ capture_1(x + y)
 capture_2(x + y)
 ```
 
-`expr()` always yields in When you need to construct an expression from known inputs use `expr()`. When you need to capture an expression provided by the user in an argument, use `enexpr()`.  
+`expr()` always yields whatever is passed in. When you need to construct an expression from known inputs use `expr()`. When you need to capture an expression provided by the user in an argument, use `enexpr()`.  
 
-Depending on how you call it `exprs()` combines some of the behaviour of `expr()` and `enexpr()`. It behaves like `enexpr()` if you pass on `...`, and behaves like `expr()` for all other arguments:
+Depending on how you call it, `exprs()` combines some of the behaviour of `expr()` and `enexpr()`. It behaves like `enexpr()` if you pass in `...`, and behaves like `expr()` for all other arguments:
 
 ```{r}
 f <- function(x, ...) {
@@ -147,7 +147,7 @@ foo <- function(...) {
 
 There's not much you can do with a list of expressions yet, but we'll see a few techniques later on in this chapter. Lists of expressions + rlang + purrr give you a surprising amount of power, which we'll get to in XXX.
 
-The opposite of quoting is evaluating. This is a big topic, so it is covered in depth in the next chapter. For now, we'll focus on a single function: `rlang::eval_tidy()`. This takes an expression and evaluates in it.
+The opposite of quoting is evaluating. This is a big topic, so it is covered in depth in the next chapter. For now, we'll focus on a single function: `rlang::eval_tidy()`. This takes an expression and evaluates it.
 
 ```{r}
 x <- expr(runif(5))
@@ -157,7 +157,7 @@ eval_tidy(x)
 eval_tidy(x)
 ```
 
-Notice that every time we evaluate this expression we get a different result. This makes these expression different to the lazy evaluation of functions which are only evaluated once, and then return the same results return again and again.
+Notice that every time we evaluate this expression we get a different result. This makes these expression different to the lazy evaluation of functions which are only evaluated once, and then return the same results again and again.
 
 Quoting functions side-step evaluation, allowing you to capture the code. This allows you to inspect and transform the AST, or evaluate the code in a different way ("non-standard") to usual. Functions that use these tools are often called non-standard evaluation (NSE) functions. 
 


### PR DESCRIPTION
Most of these are simple typo fixes, but I did run into a bit of a problem following some of the conversation around `expr`, `enexpr`, and `exprs`. I tried to fill in what I thought was missing in some of those cases, but there's a very good chance that what I filled in is wrong, so feel free to discard as you see fit.

As always, I assign the copyright of this contribution to Hadley Wickham.