### PR TITLE
Group the alike.

### DIFF
--- a/S3.Rmd
+++ b/S3.Rmd
@@ -5,6 +5,8 @@ source("common.R")
 library(sloop)
 ```
 
+??? Put in closer contact this and the introduction to this.
+
 S3 is R's first and simplest OO system. S3 is informal and ad hoc, but it has a certain elegance in its minimalism: you can't take away any part of it and still have a useful OO system. Because of these reasons, S3 should be your default choice for OO programming: you should use it unless you have a compelling reason otherwise. S3 is the only OO system used in the base and stats packages, and it's the most commonly used system in CRAN packages. \index{S3} \index{objects!S3|see{S3}} 
 
 S3 is a very flexible system: it allows you to do a lot of things that are quite ill-advised. If you're coming from a strict environment like Java, this will seem pretty frightening (and it is!) but it does give R programmers a tremendous amount of freedom. While it's very difficult to prevent someone from doing something you don't want them to do, your users will never be held back because there is something you haven't implemented yet. Since S3 has few built-in constraints, the key to its successful use is applying the constraints yourself. This chapter will teach you the conventions you should (almost) always adhere to in order to use S3 safely.


### PR DESCRIPTION
The previous section interrupts the flow between the first time S3, S4, and other OO systems are introduced and this material -- were one section is dedicated to each of those OO systems introduced earlier.

My previous comment suggested a change that is consistent with the change I suggest here. That is, if the difference between base objects and OO is moved up, then the introduction to each OO system and their respective sections will be left in closer contact to one another.