### PR TITLE
Write for programmers of functions more than for users of functions

### DIFF
--- a/S3.Rmd
+++ b/S3.Rmd
@@ -5,6 +5,8 @@ source("common.R")
 library(sloop)
 ```
 
+??? For higher impact, write not for users of S3 functions but for programmers of S3 functions.
+
 S3 is R's first and simplest OO system. S3 is informal and ad hoc, but it has a certain elegance in its minimalism: you can't take away any part of it and still have a useful OO system. Because of these reasons, S3 should be your default choice for OO programming: you should use it unless you have a compelling reason otherwise. S3 is the only OO system used in the base and stats packages, and it's the most commonly used system in CRAN packages. \index{S3} \index{objects!S3|see{S3}} 
 
 S3 is a very flexible system: it allows you to do a lot of things that are quite ill-advised. If you're coming from a strict environment like Java, this will seem pretty frightening (and it is!) but it does give R programmers a tremendous amount of freedom. While it's very difficult to prevent someone from doing something you don't want them to do, your users will never be held back because there is something you haven't implemented yet. Since S3 has few built-in constraints, the key to its successful use is applying the constraints yourself. This chapter will teach you the conventions you should (almost) always adhere to in order to use S3 safely.


### PR DESCRIPTION
This is a selfish suggestion -- I want to learn how S3 works to write functions with it. But I'll try to sell my point. 

For users, S3 just works. If you write for the users of S3 functions, I guess the reaction you can expect is: "Good to know, but this won't change anything of what I already do." But if you write for the programmers of S3 functions, then the reaction could be totally different: "Wow, I'll change my approach to programming right now!".