### PR TITLE
Many kinds of tree diagrams

### DIFF
--- a/Expressions.Rmd
+++ b/Expressions.Rmd
@@ -45,7 +45,7 @@ knitr::include_graphics("diagrams/expression-simple.png", dpi = 450)
     called. The second and subsequent children (`x`, `"y"`, and `1`) are the 
     arguments. 
   
-    __NB__: Unlike many tree diagrams the order of the children is important: 
+    __NB__: The order of the children in these tree diagarms is important: 
     `f(x, 1)` is not the same as `f(1, x)`.
     
 *   The leaves of the tree are either __symbols__, like `f` and `x`, or 


### PR DESCRIPTION
Why not just be declarative just to be more direct? As is the comparison really isn't adding anything. I can think of two kinds of widely used and known about "tree diagrams" in which order is important, TOC's (table of contents), and XML.  Except maybe for mathematicians working in graph theory most people assume order is important in tree diagrams.