### PR TITLE
Fix bug due to !! precedence

### DIFF
--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -549,7 +549,7 @@ coef_sym
 Next we need to combine each variable name with its coefficient. We can do this by combining `expr()` with map `map2()`:
 
 ```{r}
-summands <- map2(coef_sym, coefs, ~ expr((!!.x * !!.y)))
+summands <- map2(coef_sym, coefs, ~ expr((UQ(.x) * UQ(.y))))
 summands
 ```
 
@@ -563,7 +563,7 @@ summands
 Finally, we need to reduce the individual terms in to a single sum by adding the pieces together:
 
 ```{r}
-eq <- reduce(summands, ~ expr(!!.x + !!.y))
+eq <- reduce(summands, ~ expr(UQ(.x) + UQ(.y)))
 eq
 ```
 


### PR DESCRIPTION
Unless !! precedence has changed (I use rlang version 0.1.6), I cannot seem to reproduce starting with `map2(coef_sym, coefs, ~ expr((!!.x * !!.y)))`.

I propose the change to UQ() to produce the expected results