### PR TITLE
Fix code typo in `Performance.Rmd`

### DIFF
--- a/Performance.Rmd
+++ b/Performance.Rmd
@@ -78,9 +78,9 @@ The `sqrt()` function takes about `r sqrt_x` ns, or `r sqrt_x / 1000` µs, to co
    to find the average time of each operation, as in the code below.
 
     ```{r, eval = FALSE}
-    n <- 1:1e6
-    system.time(for (i in 1:n) sqrt(x)) / length(n)
-    system.time(for (i in 1:n) x ^ 0.5) / length(n)
+    n <- 1e6
+    system.time(for (i in 1:n) sqrt(x)) / n
+    system.time(for (i in 1:n) x ^ 0.5) / n
     ```
     
     How do the estimates from `system.time()` compare to those from


### PR DESCRIPTION
I assign the copyright of this contribution to Hadley Wickham.