### PR TITLE
correct R6 active fields example

### DIFF
--- a/R6.Rmd
+++ b/R6.Rmd
@@ -367,7 +367,7 @@ Person <- R6Class("Person",
       if (missing(value)) {
         private$.name
       } else {
-        stopifnot(is.character(name), length(name) == 1)
+        stopifnot(is.character(value), length(value) == 1)
         private$.name <- value
         self
       }


### PR DESCRIPTION
active values definition referenced `name` where it should have been referencing the argument `value`