### PR TITLE
updated name of rlang-function

### DIFF
--- a/Expressions.Rmd
+++ b/Expressions.Rmd
@@ -493,13 +493,13 @@ Conceptually, an expression object is just a list of expressions. The only diffe
 
 1.  How is `rlang::maybe_missing()` implemented? Why does it work?
 
-1.  `rlang::standardise_call()` doesn't work so well for the following calls.
+1.  `rlang::call_standardise()` doesn't work so well for the following calls.
     Why? What makes `mean()` special?
 
     ```{r}
-    lang_standardise(quote(mean(1:10, na.rm = TRUE)))
-    lang_standardise(quote(mean(n = T, 1:10)))
-    lang_standardise(quote(mean(x = 1:10, , TRUE)))
+    call_standardise(quote(mean(1:10, na.rm = TRUE)))
+    call_standardise(quote(mean(n = T, 1:10)))
+    call_standardise(quote(mean(x = 1:10, , TRUE)))
     ```
 
 1.  Why does this code not make sense?


### PR DESCRIPTION
- "In rlang 0.2.0, `lang_standardise()` was soft-deprecated and renamed to `call_standardise()`."