### PR TITLE
Update link to local groups

### DIFF
--- a/Introduction.Rmd
+++ b/Introduction.Rmd
@@ -29,7 +29,7 @@ If you are new to R, you might wonder what makes learning such a quirky language
   [twitter](https://twitter.com/search?q=%23rstats),
   [linkedin](http://www.linkedin.com/groups/R-Project-Statistical-Computing-77616),
   and through many local
-  [user groups](http://blog.revolutionanalytics.com/local-r-groups.html).
+  [user groups](https://jumpingrivers.github.io/meetingsR/).
 
 * Powerful tools for communicating your results. R packages make it easy to
   produce html or pdf [reports](http://yihui.name/knitr/), or create


### PR DESCRIPTION
About a year ago, we started a GitHub repo of user groups (https://github.com/jumpingrivers/meetingsR/) The Revo blog (http://blog.revolutionanalytics.com/local-r-groups.html) points to the page.