### PR TITLE
Remove redundancy from GC collector.

### DIFF
--- a/Names-values.Rmd
+++ b/Names-values.Rmd
@@ -621,7 +621,7 @@ This number won't agree with the amount of memory reported by your operating sys
 
 ### Memory leaks
 
-The GC collector takes care of deleting all objects that do not have bindings. But you are still a risk for a __memory leak__, which occurs when you keep a binding to an object without realising it. In R, the two main causes of memory leaks are formulas and functions because they both capture the enclosing environment. The following code illustrates the problem. In `f1()`, `1:1e6` is only referenced inside the function, so when the function completes the memory is returned and the net memory change is 0. `f2()` and `f3()` both return objects that capture environments, so that `x` is not freed when the function completes. \index{memory!leaks}
+The GC takes care of deleting all objects that do not have bindings. But you are still a risk for a __memory leak__, which occurs when you keep a binding to an object without realising it. In R, the two main causes of memory leaks are formulas and functions because they both capture the enclosing environment. The following code illustrates the problem. In `f1()`, `1:1e6` is only referenced inside the function, so when the function completes the memory is returned and the net memory change is 0. `f2()` and `f3()` both return objects that capture environments, so that `x` is not freed when the function completes. \index{memory!leaks}
 
 ```{r}
 f1 <- function() {


### PR DESCRIPTION
If a deletion can even have a copyright, it's mos' def Hadley Wickham's. ✍️