### PR TITLE
Update Performance.md

### DIFF
--- a/Performance.Rmd
+++ b/Performance.Rmd
@@ -158,7 +158,7 @@ microbenchmark(
 base <- last_benchmark("fun")
 ```
 
-The bare function takes about `r last_benchmark("fun")` ns. S3 method dispatch takes an additional `r last_benchmark("S3") - base` ns; S4 dispatch, `r last_benchmark("S4") - base` ns; and `r last_benchmark("RC") - base` dispatch, 10,000 ns. S3 and S4 method dispatch are expensive because R must search for the right method every time the generic is called; it might have changed between this call and the last. R could do better by caching methods between calls, but caching is hard to do correctly and a notorious source of bugs.
+The bare function takes about `r last_benchmark("fun")` ns. S3 method dispatch takes an additional `r last_benchmark("S3") - base` ns; S4 dispatch, `r last_benchmark("S4") - base` ns; and RC dispatch, `r last_benchmark("RC") - base` ns. S3 and S4 method dispatch are expensive because R must search for the right method every time the generic is called; it might have changed between this call and the last. R could do better by caching methods between calls, but caching is hard to do correctly and a notorious source of bugs.
 
 ### Name lookup with mutable environments
 


### PR DESCRIPTION
Previous version referred to RC incorrectly. It said for "10,000 dispatch, 10,000 ns" when it should have said "RC dispatch, 10,000 ns." This was corrected.