### PR TITLE
associative rule for addition

### DIFF
--- a/Expressions.Rmd
+++ b/Expressions.Rmd
@@ -216,7 +216,7 @@ lobstr::ast(1 + (2 + 3))
 
 ### Associativity
 
-Another source of ambiguity is introduced by repeated usage of the same infix function. For example, is `1 + 2 + 3` equivalent to `(1 + 2) + 3` or to `1 + (2 + 3)`?  This normally doesn't matter because `x + y == y + x`, i.e. addition is associative, but is needed because some S3 classes define `+` in a non-associative way. For example, ggplot2 overloads `+` to build up a complex plot from simple pieces; this usage is non-associative because earlier layers are drawn underneath later layers.
+Another source of ambiguity is introduced by repeated usage of the same infix function. For example, is `1 + 2 + 3` equivalent to `(1 + 2) + 3` or to `1 + (2 + 3)`?  This normally doesn't matter because `x + (y + z) == (x + y) + z`, i.e. addition is associative, but is needed because some S3 classes define `+` in a non-associative way. For example, ggplot2 overloads `+` to build up a complex plot from simple pieces; this usage is non-associative because earlier layers are drawn underneath later layers.
 
 In R, most operators are __left-associative__, i.e. the operations on the left are evaluated first:
 


### PR DESCRIPTION
what was described was the commutative rule, not the associative rule, for regular addition.