### PR TITLE
Update "Rcpp is smoking fast..." link

### DIFF
--- a/Rcpp.Rmd
+++ b/Rcpp.Rmd
@@ -1087,7 +1087,7 @@ microbenchmark(
 
 <!-- FIXME: needs more context? -->
 
-This example is adapted from ["Rcpp is smoking fast for agent-based models in data frames"](http://www.babelgraph.org/wp/?p=358). The challenge is to predict a model response from three inputs. The basic R version of the predictor looks like:
+This example is adapted from ["Rcpp is smoking fast for agent-based models in data frames"](https://gweissman.github.io/babelgraph/blog/2017/06/15/rcpp-is-smoking-fast-for-agent-based-models-in-data-frames.html). The challenge is to predict a model response from three inputs. The basic R version of the predictor looks like:
 
 ```{r}
 vacc1a <- function(age, female, ily) {


### PR DESCRIPTION
The link for "Rcpp is smoking fast for agent-based models in data frames" is dead, and it's now being rehosted at https://gweissman.github.io/babelgraph/blog/2017/06/15/rcpp-is-smoking-fast-for-agent-based-models-in-data-frames.html. I updated the link, although I understand if keeping the original link is more for citation than linking.