### PR TITLE
Without `data` argument, an error occurs

### DIFF
--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -829,7 +829,7 @@ microbenchmark::microbenchmark(
 
     ```{r}
     subset3 <- function(data, rows) {
-      eval_tidy(quo(data[!!enquo(rows), , drop = FALSE]))
+      eval_tidy(quo(data[!!enquo(rows), , drop = FALSE]), data = data)
     }
     ```
     


### PR DESCRIPTION
Without `, data = data`, the following fails with an error as shown.

```
> subset3(iris, Species == "setosa")
 Error in ~Species == "setosa" : object 'Species' not found 
```