### PR TITLE
Parent environment

### DIFF
--- a/Environments.Rmd
+++ b/Environments.Rmd
@@ -151,7 +151,7 @@ You can set the parent environment by supplying an unnamed argument to `env()`. 
 
 ```{r}
 e2a <- env(d = 4, e = 5)
-e2b <- env(e2a, a = 1, b = 2, c = 3)
+e2b <- child_env(e2a, a = 1, b = 2, c = 3)
 ```
 ```{r, echo = FALSE, out.width = NULL}
 knitr::include_graphics("diagrams/environments/parents.png", dpi = 300)


### PR DESCRIPTION
Hi, In line 154, 
e2b <- env(e2a, a = 1, b = 2, c = 3) 
will give me error like this:
Error: !length(data) || is_named(data) is not TRUE

According to the help page of env{rlang}, env() always creates a child of the current environment.
So if we want to create a parent environment, should we change it to e2b <- child_env(e2a, a = 1, b = 2, c = 3)  ?



"I assign the copyright of this contribution to Hadley Wickham"