### PR TITLE
Use nested function to demonstrate message2error.

### DIFF
--- a/Debugging.Rmd
+++ b/Debugging.Rmd
@@ -309,23 +309,26 @@ There are other ways for a function to fail apart from throwing an error or retu
 
     f <- function() g()
     g <- function() message("Hi!")
-    g()
-    # Hi!   
-    message2error(g())
+    f()
+    # Hi!
+    message2error(f())
     # Error in message("Hi!"): Hi!
     traceback()
-    # 10: stop(e) at #2
-    # 9: (function (e) stop(e))(list(message = "Hi!\n", 
-    #      call = message("Hi!")))
-    # 8: signalCondition(cond)
-    # 7: doWithOneRestart(return(expr), restart)
-    # 6: withOneRestart(expr, restarts[[1L]])
-    # 5: withRestarts()
-    # 4: message("Hi!") at #1
-    # 3: g()
-    # 2: withCallingHandlers(code, message = function(e) stop(e)) 
-    #      at #2
-    # 1: message2error(g())
+    # 11: stop(e) at #2
+    # 10: (function (e) 
+    #     stop(e))(list(message = "Hi!\n", call = message("Hi!")))
+    # 9: signalCondition(cond)
+    # 8: doWithOneRestart(return(expr), restart)
+    # 7: withOneRestart(expr, restarts[[1L]])
+    # 6: withRestarts({
+    #        signalCondition(cond)
+    #        defaultHandler(cond)
+    #    }, muffleMessage = function() NULL)
+    # 5: message("Hi!") at #1
+    # 4: g() at #1
+    # 3: f() at #2
+    # 2: withCallingHandlers(code, message = function(e) stop(e)) at #2
+    # 1: message2error(f())
     ```
 
     As with warnings, you'll need to ignore some of the calls on the traceback


### PR DESCRIPTION
When demonstrating the behavior of `withCallingHandlers()` via `message2error()`, a function `f()` is defined but never used. I updated the example to use this function. A later exercise (currently in [Conditions.Rmd](https://github.com/hadley/adv-r/blob/a36fa316a6040f8d27e7dff706b2348be250afd6/Conditions.Rmd)) compares the difference in the call stacks when `message2error()` is implemented with `withCallingHandlers()` versus `tryCatch()`. The difference is more noticeable when the message is produced within a nested function, i.e. the first entry `message2error(g())` in the traceback after using `tryCatch()` appears rather informative since `g()` itself contains the message.


I assign the copyright of this contribution to Hadley Wickham.