### PR TITLE
Swap order matrix arguments

### DIFF
--- a/Data-structures.Rmd
+++ b/Data-structures.Rmd
@@ -374,7 +374,7 @@ Matrices and arrays are created with `matrix()` and `array()`, or by using the a
 
 ```{r}
 # Two scalar arguments to specify rows and columns
-a <- matrix(1:6, ncol = 3, nrow = 2)
+a <- matrix(1:6, nrow = 2, ncol = 3)
 # One vector argument to describe all dimensions
 b <- array(1:12, c(2, 3, 2))
 


### PR DESCRIPTION
This is less confusing as it is consistent:

- with the default matrix argument order

`matrix(data = NA, nrow = 1, ncol = 1, byrow = FALSE,
       dimnames = NULL)`

- with the corresponding vectorized form

`matrix(1:6, c(2, 3))`