### PR TITLE
Fixed two typos related to warnings

### DIFF
--- a/Conditions.Rmd
+++ b/Conditions.Rmd
@@ -171,7 +171,7 @@ You can control this behaviour with the `warn` option:
 
 Like `stop()`, `warning()` also has a call argument. It is slightly more useful (since warnings are often more distant from their source), but I still generally suppress it with `call. = FALSE`. The rlang wrapper, `rlang::warn()`, also suppresses by default.
 
-Warnings occupy a somewhat awkward limnal state between messages ("you should know about this") and errors ("you must fix this"). You should be cautious with your use of `warnings()`: warnings are easy to miss if there's a lot of other output, and you don't want your function to recover too easily from clearly incorrect input. In my opinion, base R tends to overuse warnings, and many warnings in base R would be better off as clear errors. For example, take `read.csv()`, which uses the the `file()` function. The file function simple warns if the file exists. That means that when you try and read a file that does not exist, you get both a warning and an error:
+Warnings occupy a somewhat awkward limnal state between messages ("you should know about this") and errors ("you must fix this"). You should be cautious with your use of `warnings()`: warnings are easy to miss if there's a lot of other output, and you don't want your function to recover too easily from clearly incorrect input. In my opinion, base R tends to overuse warnings, and many warnings in base R would be better off as clear errors. For example, take `read.csv()`, which uses the the `file()` function. The file function simply warns if the file does not exist. That means that when you try to read a file that does not exist, you get both a warning and an error:
 
 ```{r, error = TRUE}
 read.csv("blah.csv")


### PR DESCRIPTION
1) file() warns if the file _does not_ exist
2) when you try _to_ read, not try _and_ read  (style)