### PR TITLE
Add attributes(a) before examples

### DIFF
--- a/Data-structures.Rmd
+++ b/Data-structures.Rmd
@@ -258,6 +258,7 @@ structure(1:10, my_attribute = "This is a vector")
 By default, most attributes are lost when modifying a vector:
 
 ```{r}
+attributes(a)
 attributes(a[1])
 attributes(sum(a))
 ```


### PR DESCRIPTION
Made attributes examples clearer since they were returning NULL and NULL, not giving the correct impression of loosing attributes.