### PR TITLE
Avoid confusion with S3 styles

### DIFF
--- a/S3.Rmd
+++ b/S3.Rmd
@@ -107,10 +107,10 @@ S3 is a simple and ad hoc system, and has no formal definition of a class. To ma
 
 ```{r}
 # Create and assign class in one step
-foo <- structure(list(), class = "foo")
+foo <- structure(1:3, class = "foo")
 
 # Create, then set class
-foo <- list()
+foo <- 1:3
 class(foo) <- "foo"
 ```
 


### PR DESCRIPTION
In the context of S3 styles, the `list()` in `structure(list() ... ` confuses me. It suggests that all S3 objects are built on top of a list. This gets confusing because the scalar-style does build on top of lists.

Another source of confusion is that the list is empty. From the viewpoint of the data structure, an empty list is indeed simple. But from the viewpoint of a struggling reader (and I've read this topic multiple times), an empty list is not simple because it is a data structure I deal with almost never. It takes me extra effort to understant if the data doesn't __have__ to be an empty list and instead can be any object. 