### PR TITLE
Typo?

### DIFF
--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -117,7 +117,7 @@ Understanding how `base::local()` works is harder, as it uses `eval()` and `subs
 
 ### Application: `source()`
 
-We can create a simple version of `source()` by combining `expr_text()` and `eval_bare()`. We read in the file from disk, use `parse_expr()` to parse the string into a list of expressions, and then use `eval_bare()` to evaluate each component in turn. This version evaluates the code in the caller environment, and invisibly returns the result of the last expression in the file like `source()`. \index{source()}
+We can create a simple version of `source()` by combining `parse_expr()` and `eval_bare()`. We read in the file from disk, use `parse_expr()` to parse the string into a list of expressions, and then use `eval_bare()` to evaluate each component in turn. This version evaluates the code in the caller environment, and invisibly returns the result of the last expression in the file like `source()`. \index{source()}
 
 ```{r}
 source2 <- function(path, env = caller_env()) {


### PR DESCRIPTION
`expr_text()` is nowhere used in this code chunk. Did you mean `parse_exprs()`?