### PR TITLE
Use new function name

### DIFF
--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -511,7 +511,7 @@ The data mask is the key idea that powers base functions like `with()`, `subset(
 How does this work? Unlike environments, data frames don't have parents, so we can effectively turn it into an environment using the environment of the quosure as its parent. The above code is basically equivalent to:
 
 ```{r}
-df_env <- as_env(df, parent = quo_get_env(q1))
+df_env <- as_environment(df, parent = quo_get_env(q1))
 q2 <- quo_set_env(q1, df_env)
 
 eval_tidy(q2)


### PR DESCRIPTION
According to the rlang documentation, as_env() has been soft-deprecated and renamed to as_environment(), hence suggesting a change.

I assign the copyright of this contribution to Hadley Wickham