### PR TITLE
Added missing dot to "data"

### DIFF
--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -636,7 +636,7 @@ What if we generalise `threshold_x()` slightly so that the user can pick the var
 ```{r}
 threshold_var1 <- function(df, var, val) {
   var <- ensym(var)
-  subset2(df, `$`(data, !!var) >= !!val)
+  subset2(df, `$`(.data, !!var) >= !!val)
 }
 
 threshold_var2 <- function(df, var, val) {
@@ -645,7 +645,7 @@ threshold_var2 <- function(df, var, val) {
 }
 ```
 
-In `threshold_var1` we need to use the prefix form of `$`, because `df$!!var` is not valid R syntax. Alternatively, we can convert the symbol to a string, and use `[[`.
+In `threshold_var1` we need to use the prefix form of `$`, because `.data$!!var` is not valid R syntax. Alternatively, we can convert the symbol to a string, and use `[[`.
 
 Note that it is not always the responsibility of the function author to avoid ambiguity. Imagine we generalise further to allow thresholding based on any expression:
 


### PR DESCRIPTION
The example function threshold_var1 does not run the way it is defined now. Added "." in front of data, and changed the explanation of the code accordingly.

I assign the copyright of this contribution to Hadley Wickham