### PR TITLE
Clarification of Evaluation example

### DIFF
--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -70,7 +70,7 @@ Note that the first argument to `eval_bare()` (and to `base::eval()`) is evaluat
 
 ```{r}
 eval_bare(x + y)
-eval_bare(x + y, env = env)
+eval_bare(x + y, env(x = 1000))
 ```
 
 Now that you've seen the basics, let's explore some applications. We'll focus primarily on base R functions that you might have used before; now you can learn how they work. To focus on the underlying principles, we'll extract out their essence, and rewrite to use rlang functions. Once you've seen some applications, we'll circle back and talk about more about `base::eval()`.


### PR DESCRIPTION
I wonder if this example would be clearer for the reader if `env` was defined, even though it does not matter for the result of this function. Then  `eval_bare(x + y, env(x = 1000))` gives 12 while `eval_bare(expr(x + y), env(x = 1000))` gives 1002. 

As it is now, `eval_bare(expr(x + y), env = env)` fails, since `env` is a function, not an environment.

I assign the copyright of this commit to Hadley Wickham.