### PR TITLE
Spelling fix in Environments.Rmd

### DIFF
--- a/Environments.Rmd
+++ b/Environments.Rmd
@@ -129,7 +129,7 @@ In R 3.2.0 and greater, use `names()` to list the bindings in an environment. If
 
 ### Important environments
 
-We'll talk in detail about special environments in [Special environments], but for now we need to mention two. The current environment, or `current_env()` is the environment in which code is currently executing. When you're experimenting interactively, that's usually the global environment, or `global_env()`. The global environment is sometimes called your "workspace", as it's where all interactive (i.e. outside of a funtion) computation takes place.
+We'll talk in detail about special environments in [Special environments], but for now we need to mention two. The current environment, or `current_env()` is the environment in which code is currently executing. When you're experimenting interactively, that's usually the global environment, or `global_env()`. The global environment is sometimes called your "workspace", as it's where all interactive (i.e. outside of a function) computation takes place.
 
 Note that to compare environments, you need to use `identical()` and not `==`:
 
@@ -806,7 +806,7 @@ The frame is an extremely important internal data structure, and R code can only
   what `traceback()` prints out.
 
 * An environment (labelled with `env`), which is typically the execution 
-  environment of a funtion. There are two main exceptions: the environment of 
+  environment of a function. There are two main exceptions: the environment of 
   the global frame is the global environment, and calling `eval()` also 
   generates frames, where the environment can be anything.
 

--- a/Environments.Rmd
+++ b/Environments.Rmd
@@ -538,7 +538,7 @@ In diagrams, I'll depict functions as rectangles with a rounded end that binds a
 knitr::include_graphics("diagrams/environments/binding.png", dpi = 300)
 ```
 
-In this case, `f()` binds the environment that binds the name `f` to the function. But that's not always the case: in the following example `g` is bound in a new environment `e`, but `g()` binds the global environment. The distinction being binding and being bound by is subtle but important; the difference is how we find `g` vs. how `g` finds its variables.
+In this case, `f()` binds the environment that binds the name `f` to the function. But that's not always the case: in the following example `g` is bound in a new environment `e`, but `g()` binds the global environment. The distinction between binding and being bound by is subtle but important; the difference is how we find `g` vs. how `g` finds its variables.
 
 ```{r}
 e <- env()

--- a/Environments.Rmd
+++ b/Environments.Rmd
@@ -820,7 +820,7 @@ knitr::include_graphics("diagrams/environments/calling.png", dpi = 300)
 
 (To focus on the calling environments, I have omitted the bindings in the global environment from `f`, `g`, and `h` to the respective function objects.)
 
-The frame also holds exit handlers created with `on.exit()`, restarts and handlers for the the condition system, and which context to `return()` to when a function completes. These are important for the internal operation of R, but are not directly accessible.
+The frame also holds exit handlers created with `on.exit()`, restarts and handlers for the condition system, and which context to `return()` to when a function completes. These are important for the internal operation of R, but are not directly accessible.
 
 ### Dynamic scope
 

--- a/Environments.Rmd
+++ b/Environments.Rmd
@@ -464,7 +464,7 @@ f2 <- function(..., env = caller_env()) {
 ## Special environments {#function-envs}
 \index{functions!environments}
  
-Most environments are not created by you (e.g. with `env()`) but are instead created by R. In this section, you'll learn about the most important environments, starting with the package environments. You'll then learn then about the function environment bound to the function when it is created, and the (usually) ephemeral execution environment created every time the function is called. Finally, you'll see how the package and function environments interact to support namespaces, which ensure that a package always behaves the same way, regardless of what other packages the user has loaded.
+Most environments are not created by you (e.g. with `env()`) but are instead created by R. In this section, you'll learn about the most important environments, starting with the package environments. You'll then learn about the function environment bound to the function when it is created, and the (usually) ephemeral execution environment created every time the function is called. Finally, you'll see how the package and function environments interact to support namespaces, which ensure that a package always behaves the same way, regardless of what other packages the user has loaded.
 
 ### Package environments and the search path
 \indexc{search()} \index{search path}

--- a/Environments.Rmd
+++ b/Environments.Rmd
@@ -725,7 +725,7 @@ There is one last environment we need to explain, the __caller__ environment, ac
 `parent.frame()` is equivalent to `caller_env()`; just note that it returns an environment, not a frame.
 ::: 
 
-To fully understand the caller environment we need to discuss two related concepts: the __call stack__, which is made up of __frames__. Executing a function creates two types of context. You've learn about one already: the execution environment is a child of the function environment, which is determined by where the function was created. There's another type of context created by where the function was called: this is called the call stack.
+To fully understand the caller environment we need to discuss two related concepts: the __call stack__, which is made up of __frames__. Executing a function creates two types of context. You've learned about one already: the execution environment is a child of the function environment, which is determined by where the function was created. There's another type of context created by where the function was called: this is called the call stack.
 
 There are also a couple of small wrinkles when it comes to custom evaluation. See [environments vs. frames](#eval-frame) for more details.
 

--- a/Environments.Rmd
+++ b/Environments.Rmd
@@ -590,7 +590,7 @@ Every namespace environment has the same set of ancestors:
   parent.
   
 * The parent of the base namespace is the global environment. This means that 
-  if a binding isn't defined in the imports environment the packge will look
+  if a binding isn't defined in the imports environment the package will look
   for it in the usual way. This is usually a bad idea (because it makes code
   depend on other loaded packages), so `R CMD check` automatically warns about
   such code. It is needed primarily for historical reasons, particularly due 

--- a/Environments.Rmd
+++ b/Environments.Rmd
@@ -518,7 +518,7 @@ knitr::include_graphics("diagrams/environments/search-path-2.png", dpi = 300)
 ### The function environment
 \index{environments!function}
 
-A function binds the current environment when it is created. This is called the __function environment__, and is used for lexical scoping. Across computer languages, functions that capture their environments are called __closures__, which why this term is often used interchangeably with function in R's documentation.
+A function binds the current environment when it is created. This is called the __function environment__, and is used for lexical scoping. Across computer languages, functions that capture their environments are called __closures__, which is why this term is often used interchangeably with function in R's documentation.
 
 You can get the function environment with `fn_env()`: 
 


### PR DESCRIPTION
Removed the last "then" in "You'll then learn then about the function environment ...", as well as some other small fixes.

I assign the copyright of this commit to Hadley Wickham.