### PR TITLE
Argument to rlang::abort()

### DIFF
--- a/Conditions.Rmd
+++ b/Conditions.Rmd
@@ -539,7 +539,7 @@ h <- function() message("!")
 
 One of the challenges of error handling in R is that most functions generate one of the default conditions, which consist only of a `message` and `call`. If you want to detect a specific error message, you must compute on the text of the error message. This is error prone, not only because the message might change over time, but also because messages can be translated into other languages. 
 
-Fortunately R has a powerful but little used feature: the ability to use custom condition objects which can contain additional metadata. It is somewhat fiddly to create custom conditions in base R, but rlang makes it very easy: in `rlang::abort()` and friends you can supply a custom `.class` and additional metadata. 
+Fortunately R has a powerful but little used feature: the ability to use custom condition objects which can contain additional metadata. It is somewhat fiddly to create custom conditions in base R, but rlang makes it very easy: in `rlang::abort()` and friends you can supply a custom `.subclass` and additional metadata. 
 
 ```{r, error = TRUE}
 abort(


### PR DESCRIPTION
The argument to abort and friends seems to be called `.subclass`.