### PR TITLE
Abort needs named message argument

### DIFF
--- a/Conditions.Rmd
+++ b/Conditions.Rmd
@@ -573,10 +573,10 @@ I think we can do better by being explicit about which argument is the problem (
 ```{r}
 log <- function(x, base = exp(1)) {
   if (!is.numeric(x)) {
-    abort("`x` must be a numeric vector; not ", typeof(x))
+    abort(message = glue::glue("`x` must be a numeric vector; not ", typeof(x)))
   }
   if (!is.numeric(base)) {
-    abort("`base` must be a numeric vector; not ", typeof(base))
+    abort(message = glue::glue("`base` must be a numeric vector; not ", typeof(base)))
   }
 
   base::log(x, base = base)

--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -10,9 +10,9 @@ The user-facing opposite of quotation is unquotation: it gives the _user_ the ab
 
 This chapter begins with a discussion of evaluation in its purest form with `rlang::eval_bare()` which evaluates an expression in given environment. We'll then see how these ideas are used to implement a handful of base R functions, and then learn about the similar `base::eval()`.
 
-The meat of the chapter focusses on extensions needed to implement evaluation robustly. There are are two big new ideas:
+The meat of the chapter focusses on extensions needed to implement evaluation robustly. There are two big new ideas:
 
-*   We need a new data structure that captures both the expression __and__ then
+*   We need a new data structure that captures both the expression __and__ the
     environment associated with each function argument. We call this data 
     structure a __quosure__.
     
@@ -21,7 +21,7 @@ The meat of the chapter focusses on extensions needed to implement evaluation ro
     and to resolve the ambiguity it creates, introduce the idea of data
     pronouns.
 
-Together, quasiquotation, quosures, data masks, and pronouns form what we call __tidy evaluation__, or tidy eval for short. Tidy eval provides a principled approach to NSE that makes it possible to use such functions both interactively and embedded with other functions. We'll finish off the chapter showing the basic pattern you use to wrap quasiquoting functions, and how you can adapt that pattern base R NSE functions.
+Together, quasiquotation, quosures, data masks, and pronouns form what we call __tidy evaluation__, or tidy eval for short. Tidy eval provides a principled approach to NSE that makes it possible to use such functions both interactively and embedded with other functions. We'll finish off the chapter showing the basic pattern you use to wrap quasiquoting functions, and how you can adapt that pattern to base R NSE functions.
 
 ### Outline {-}
 
@@ -94,7 +94,7 @@ x
 y
 ```
 
-The essence of `local()` is quite simple. We capture the input expression, and create an new environment in which to evaluate it. This inherits from the caller environment so it can access the current lexical scope, but any intermediate variables will be GC'd once the function has returned. 
+The essence of `local()` is quite simple. We capture the input expression, and create a new environment in which to evaluate it. This inherits from the caller environment so it can access the current lexical scope, but any intermediate variables will be GC'd once the function has returned. 
 
 ```{r, error = TRUE}
 local2 <- function(expr) {
@@ -245,16 +245,17 @@ While `source3()` is considerably more concise than `source2()`, this one use ca
 1.   We can make `base::local()` slightly easier to understand by spreading
     out over multiple lines:
 
-    ```{r}
-    local3 <- function(expr, envir = new.env()) {
-      call <- substitute(eval(quote(expr), envir))
-      eval(call, envir = parent.frame())
-    }
-    ```
+
+```{r}
+local3 <- function(expr, envir = new.env()) {
+  call <- substitute(eval(quote(expr), envir))
+  eval(call, envir = parent.frame())
+}
+```
     
-    Explain how `local()` works in words. (Hint: you might want to `print(call)`
-    to help understand what `substitute()` is doing, and read the documentation
-    to remind yourself what environment `new.env()` will inherit from.)
+Explain how `local()` works in words. (Hint: you might want to `print(call)`
+to help understand what `substitute()` is doing, and read the documentation
+to remind yourself what environment `new.env()` will inherit from.)
     
 ## Quosures
 

--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -245,17 +245,16 @@ While `source3()` is considerably more concise than `source2()`, this one use ca
 1.   We can make `base::local()` slightly easier to understand by spreading
     out over multiple lines:
 
-
-```{r}
-local3 <- function(expr, envir = new.env()) {
-  call <- substitute(eval(quote(expr), envir))
-  eval(call, envir = parent.frame())
-}
-```
+    ```{r}
+    local3 <- function(expr, envir = new.env()) {
+      call <- substitute(eval(quote(expr), envir))
+      eval(call, envir = parent.frame())
+    }
+    ```
     
-Explain how `local()` works in words. (Hint: you might want to `print(call)`
-to help understand what `substitute()` is doing, and read the documentation
-to remind yourself what environment `new.env()` will inherit from.)
+    Explain how `local()` works in words. (Hint: you might want to `print(call)`
+    to help understand what `substitute()` is doing, and read the documentation
+    to remind yourself what environment `new.env()` will inherit from.)
     
 ## Quosures
 


### PR DESCRIPTION
Changed the call to `abort()`. Here is a reprex showing the change.

``` r
# I use rlang 0.2.0.9001 and R 3.5.0.
library(rlang)

# Function defined in adv-r
log <- function(x, base = exp(1)) {
  if (!is.numeric(x)) {
    abort("`x` must be a numeric vector; not ", typeof(x))
  }
  if (!is.numeric(base)) {
    abort("`base` must be a numeric vector; not ", typeof(base))
  }
  
  base::log(x, base = base)
}

log(letters)
#> Error: `x` must be a numeric vector; not
log(1:10, base = letters)
#> Error: `base` must be a numeric vector; not

# Function with named message argument and glue::glue()
log2 <- function(x, base = exp(1)) {
  if (!is.numeric(x)) {
    abort(message = glue::glue("`x` must be a numeric vector; not ", typeof(x)))
  }
  if (!is.numeric(base)) {
    abort(message = glue::glue("`base` must be a numeric vector; not ", typeof(base)))
  }
  
  base::log(x, base = base)
}

log2(letters)
#> Error: `x` must be a numeric vector; not character
log2(1:10, base = letters)
#> Error: `base` must be a numeric vector; not character
```
