### PR TITLE
fix typo and hide results of conceptual exercise

### DIFF
--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -268,7 +268,7 @@ There are two other important base quoting functions that we'll cover elsewhere:
 1.  Compare and contrast the following two functions. Can you predict the
     ouput before running them?
 
-    ```{r, result = FALSE}
+    ```{r, results = FALSE}
     f1 <- function(x, y) {
       exprs(x = x, y = y)
     }


### PR DESCRIPTION
in file Quotation.Rmd

Now the results of a conceptual exercise are kept hidden.

 I assign the copyright of this contribution to Hadley Wickham