### PR TITLE
Adding elements to list does not work as intended

### DIFF
--- a/Function-operators.Rmd
+++ b/Function-operators.Rmd
@@ -291,6 +291,8 @@ Unfortunately there's a problem with this implementation because function argume
 funs <- list(mean = mean, sum = sum)
 
 funs_m <- vector("list", length(funs))
+names(funs_m) <- names(funs)
+
 for (fun in names(funs)) {
   funs_m[[fun]] <- delay_by(funs[[fun]], delay = 0.1)
 }
@@ -309,6 +311,8 @@ delay_by <- function(delay, f) {
 }
 
 funs_m <- vector("list", length(funs))
+names(funs_m) <- names(funs)
+
 for (fun in names(funs)) {
   funs_m[[fun]] <- delay_by(funs[[fun]], delay = 0.1)
 }


### PR DESCRIPTION
I believe that the for loops for adding elements to funs_m does not work as intended in these two examples. Here is the output from the current code: `funs_m` is first defined with two `NULL` elements, and then it gets two new elements, with names `mean` and `sum`, which are appended. It hence has length four.

``` r
delay_by <- function(delay, f) {
  function(...) {
    Sys.sleep(delay)
    f(...)
  }
}

funs <- list(mean = mean, sum = sum)

funs_m <- vector("list", length(funs))
for (fun in names(funs)) {
  funs_m[[fun]] <- delay_by(funs[[fun]], delay = 0.1)
}
funs_m$mean(1:10)
#> [1] 55

length(funs_m)
#> [1] 4
names(funs_m)
#> [1] ""     ""     "mean" "sum"
```
With the proposed fix, we get this instead. By setting the names of `funs_m` equal to the names of `funs`, the functions are added to the existing elements of the list, rather than appended.

``` r
delay_by <- function(delay, f) {
  function(...) {
    Sys.sleep(delay)
    f(...)
  }
}

funs <- list(mean = mean, sum = sum)

funs_m <- vector("list", length(funs))
# The following line is the proposed fix:
names(funs_m) <- names(funs)

for (fun in names(funs)) {
  funs_m[[fun]] <- delay_by(funs[[fun]], delay = 0.1)
}
funs_m$mean(1:10)
#> [1] 55

length(funs_m)
#> [1] 2
names(funs_m)
#> [1] "mean" "sum"
```
Exactly the same logic applies to the subsequent example, with forced evaluation.


I assign the copyright of this commit to Hadley Wickham.