### PR TITLE
Is the is.array() function described correctly?

### DIFF
--- a/base-types.Rmd
+++ b/base-types.Rmd
@@ -139,7 +139,7 @@ is.primitive(sum)
       
     * `is.matrix(x)` tests if `length(dim(x))` is 2.
     
-    * `is.array(x)` tests if `x` has a `dim` attribute of length 1+.
+    * `is.array(x)` tests if `length(dim(x))` is greater than zero.
     
 *   Has an S3 class: `is.data.frame()`, `is.factor()`, `is.numeric_version()`,
     `is.ordered()`, `is.package_version()`, `is.qr()`, `is.table()`.

--- a/base-types.Rmd
+++ b/base-types.Rmd
@@ -139,7 +139,7 @@ is.primitive(sum)
       
     * `is.matrix(x)` tests if `length(dim(x))` is 2.
     
-    * `is.array(x)` tests if `length(dim(x))` is 1 or 3+.
+    * `is.array(x)` tests if `x` has a `dim` attribute of length 1+.
     
 *   Has an S3 class: `is.data.frame()`, `is.factor()`, `is.numeric_version()`,
     `is.ordered()`, `is.package_version()`, `is.qr()`, `is.table()`.


### PR DESCRIPTION
The way it is written in the bullet point, `is.array(x)` should return `FALSE` if `x` is a matrix. As far as I can tell, this is not correct, hence the suggested fix. Here is an example:

``` r
x <- matrix(rnorm(6), nrow = 3, ncol = 2)
length(dim(x))
#> [1] 2
is.array(x)
#> [1] TRUE
```

Quoting from the documentation for `is.array`: 

> is.array returns TRUE or FALSE depending on whether its argument is an array (i.e., has a dim attribute of positive length) or not.

I assign the copyright of this commit to Hadley Wickham.