### PR TITLE
Typo in explanation of environment ancestors

### DIFF
--- a/Environments.Rmd
+++ b/Environments.Rmd
@@ -157,7 +157,7 @@ e2b <- env(e2a, a = 1, b = 2, c = 3)
 knitr::include_graphics("diagrams/environments/parents.png", dpi = 300)
 ```
 
-We use the metaphor of a family to name environments relative to one another. The grandparent of an environment is the parent's parent, and the ancestors include all parent environments up to the empty environment. To save space, I typically won't draw all the ancestors; just remember whenever you see a pale blue circle, there's an parent environment somewhere.
+We use the metaphor of a family to name environments relative to one another. The grandparent of an environment is the parent's parent, and the ancestors include all parent environments up to the empty environment. To save space, I typically won't draw all the ancestors; just remember whenever you see a pale blue circle, there's a parent environment somewhere.
 
 You can find the parent of an environment with `env_parent()`:
 


### PR DESCRIPTION
"an parent" to "a parent"