### PR TITLE
rename use of lang_standardise to call_standardise

### DIFF
--- a/Expressions.Rmd
+++ b/Expressions.Rmd
@@ -34,9 +34,9 @@ eval(z)
 y
 ```
 
-### Outline {-} 
+### Outline {-}
 
-### Prerequisites {-} 
+### Prerequisites {-}
 
 Make sure you've installed rlang and lobstr from GitHub:
 
@@ -52,18 +52,18 @@ Quoted expressions are also called abstract syntax trees (AST) because the struc
 ```{r, echo = FALSE, out.width = NULL}
 knitr::include_graphics("diagrams/expressions/simple.png", dpi = 300)
 ```
-  
+
 *   Function __calls__ define the hierarchy of the tree. Calls are shown
-    with an orange square. The first child (`f`) is the function that gets 
-    called; the second and subsequent children (`x`, `"y"`, and `1`) are the 
-    arguments. 
-  
-    __NB__: Unlike many tree diagrams the order of the children is important: 
+    with an orange square. The first child (`f`) is the function that gets
+    called; the second and subsequent children (`x`, `"y"`, and `1`) are the
+    arguments.
+
+    __NB__: Unlike many tree diagrams the order of the children is important:
     `f(x, 1)` is not the same as `f(1, x)`.
-    
-*   The leaves of the tree are either __symbols__, like `f` and `x`, or 
-    __constants__ like `1` or `"y"`. Symbols have a purple border and rounded 
-    corners. Constants, which are atomic vectors of length one, have black 
+
+*   The leaves of the tree are either __symbols__, like `f` and `x`, or
+    __constants__ like `1` or `"y"`. Symbols have a purple border and rounded
+    corners. Constants, which are atomic vectors of length one, have black
     borders and square corners. Strings are always surrounded in quotes to
     emphasise their difference from symbols --- more on that later.
 
@@ -91,7 +91,7 @@ For more complex code, you can also use RStudio's tree viewer to explore the AST
 
 ### Infix vs. prefix calls
 
-Every call in R can be written in tree form, even if it doesn't look like it at first glance. Take `y <- x * 10` again: what are the functions that are being called? It is not as easy to spot as `f(x, 1)` because this expression contains two calls in __infix__ form: `<-` and `*`. Infix functions come **in**between their arguments (so an infix function can only have two arguments), whereas most functions in R are __prefix__ functions where the name of the function comes first [^1]. 
+Every call in R can be written in tree form, even if it doesn't look like it at first glance. Take `y <- x * 10` again: what are the functions that are being called? It is not as easy to spot as `f(x, 1)` because this expression contains two calls in __infix__ form: `<-` and `*`. Infix functions come **in**between their arguments (so an infix function can only have two arguments), whereas most functions in R are __prefix__ functions where the name of the function comes first [^1].
 
 [^1]: Some programming languages use __postfix__ calls where the name of the function comes last. If you ever used an old HP calculator, you might have fallen in love with reverse Polish notation, postfix notation for algebra. There is also a family of "stack"-based programming languages descending from Forth which takes this idea as far as it might possibly go.
 
@@ -154,7 +154,7 @@ And of course that function might also take arguments:
 lobstr::ast(f(b, 2)(a, 1))
 ```
 
-These forms are relatively rare, but it's good to be able to recognise them when they crop up. 
+These forms are relatively rare, but it's good to be able to recognise them when they crop up.
 
 ### Argument names
 
@@ -168,21 +168,21 @@ lobstr::ast(mean(x = mtcars$cyl, na.rm = TRUE))
 
 ### Exercises
 
-1.  Use `ast()` and experimentation to figure out the three arguments to `if()`. 
-    What would you call them? Which arguments are required and which are 
-    optional? 
+1.  Use `ast()` and experimentation to figure out the three arguments to `if()`.
+    What would you call them? Which arguments are required and which are
+    optional?
 
-1.  What does the call tree of an `if` statement with multiple `else if` 
+1.  What does the call tree of an `if` statement with multiple `else if`
     conditions look like? Why?
-    
-1.  What are the arguments to the `for()` and `while()` calls? 
+
+1.  What are the arguments to the `for()` and `while()` calls?
 
 1.  Two arithmetic operators can be used in both prefix and infix style.
     What are they?
 
 ## R's grammar
 
-The process by which a computer language takes a sequence of tokens (like `x`, `+`, `y`) and constructs a tree is called __parsing__, and it is governed by a set of rules known as a __grammar__. In this section, we'll use `lobstr::ast()` to explore some of the details of R's grammar. 
+The process by which a computer language takes a sequence of tokens (like `x`, `+`, `y`) and constructs a tree is called __parsing__, and it is governed by a set of rules known as a __grammar__. In this section, we'll use `lobstr::ast()` to explore some of the details of R's grammar.
 
 If this is your first reading of the metaprogramming chapters, now is a good time to read the first sections of the next two chapters in order to get the big picture. Come back and learn more of the details once you've seen how all the big pieces fit together.
 
@@ -196,7 +196,7 @@ Infix functions introduce ambiguity in a way that prefix functions do not. The p
 knitr::include_graphics("diagrams/expressions/ambig-order.png", dpi = 300)
 ```
 
-Programming langauges use conventions called __operator precedence__ to resolve this ambiguity. We can use `ast()` to see what R does: 
+Programming langauges use conventions called __operator precedence__ to resolve this ambiguity. We can use `ast()` to see what R does:
 
 ```{r}
 lobstr::ast(1 + 2 * 3)
@@ -242,24 +242,24 @@ lobstr::ast(y < -x)
 
 ### Exercises
 
-1.  R uses parentheses in two slightly different ways as illustrated by 
+1.  R uses parentheses in two slightly different ways as illustrated by
     these two calls:
-    
+
     ```{r, eval = FALSE}
     f((1))
     `(`(1 + 1)
     ```
-    
-    Compare and contrast the two uses by referencing the AST. 
-    
-1.  `=` can also be used in two ways. Construct a simple example that shows 
+
+    Compare and contrast the two uses by referencing the AST.
+
+1.  `=` can also be used in two ways. Construct a simple example that shows
     both uses.
 
 1.  What does `!1 + !1` return? Why?
 
 1.  Why does `x1 <- x2 <- x3 <- 0` work? There are two reasons.
 
-1.  Compare the ASTs `x + y %+% z` and `x ^ y %+% z`. What does that tell you 
+1.  Compare the ASTs `x + y %+% z` and `x ^ y %+% z`. What does that tell you
     about the precedence of custom infix functions?
 
 ## Data structures
@@ -268,14 +268,14 @@ Now that you have a good feel for ASTs and how R's grammar helps to define them,
 
 * Constants and symbols form the leaves of the tree.
 * Calls form the branches of the tree.
-* Pairlists are a largely historical data structure that are now only used for 
+* Pairlists are a largely historical data structure that are now only used for
   function arguments.
 
 ### Naming conventions
 
-Before we continue, a word of caution about the naming conventions used in this book. Because base R evolved organically, it does not have a set of names that are used consistently throughout all functions. Instead, we've adopted our own set of conventions, and used them consistently throughout the book and in rlang. You will need to remember some translations when reading base R documentation. 
+Before we continue, a word of caution about the naming conventions used in this book. Because base R evolved organically, it does not have a set of names that are used consistently throughout all functions. Instead, we've adopted our own set of conventions, and used them consistently throughout the book and in rlang. You will need to remember some translations when reading base R documentation.
 
-The biggest difference is the use of the term "expression". We use expression to . In base R, "expression" is a special type that is basically equivalent to a list of what we call expressions. To avoid confusion we'll call these __expression objects__, and we'll discuss them in [expression objects]. 
+The biggest difference is the use of the term "expression". We use expression to . In base R, "expression" is a special type that is basically equivalent to a list of what we call expressions. To avoid confusion we'll call these __expression objects__, and we'll discuss them in [expression objects].
 
 Base R does not have an equivalent term for our "expression". The closest is "language object", which includes symbols and calls, but not constants or pairlists. But note that `typeof()` and `str()` use "language" not for language objects, but instead to mean calls. Base R uses symbol and name interchangeably; we prefer symbol because "name" has other common meanings (e.g. the name of a variable).
 
@@ -388,10 +388,10 @@ x[[2]]
 x$row
 ```
 
-Extracting specific arguments from calls is challenging because of R's flexible rules for argument matching: it could potentially be in any location, with the full name, with an abreviated name, or with no name. To work around this problem, you can use `rlang::lang_standardise()` which standardises all arguments to use the full name: \indexc{standardise\_call()}
+Extracting specific arguments from calls is challenging because of R's flexible rules for argument matching: it could potentially be in any location, with the full name, with an abreviated name, or with no name. To work around this problem, you can use `rlang::call_standardise()` which standardises all arguments to use the full name: \indexc{standardise\_call()}
 
 ```{r}
-rlang::lang_standardise(x)
+rlang::call_standardise(x)
 ```
 
 (Note that if the function uses `...` it's not possible to standardise all arguments.)
@@ -424,7 +424,7 @@ lang(expr(mean), x = expr(x), na.rm = TRUE)
 
 ### Pairlists
 \index{pairlists}
- 
+
 There is one data structure we need to discuss for completeness: the pairlist. Pairlists are a remnant of R's past and have been replaced by lists almost everywhere. The only place you are likely to see pairlists in R is when working with function arguments:
 
 ```{r}
@@ -433,7 +433,7 @@ typeof(formals(f))
 ```
 
 (If you're working in C, you'll encounter pairlists more often. For example, calls are also implemented using pairlists.)
- 
+
 Fortunately, whenever you encounter a pairlist, you can treat it just like a regular list:
 
 ```{r}
@@ -457,7 +457,7 @@ microbenchmark::microbenchmark(
 ```
 
 ### Expression objects
-\index{expression object} \indexc{expression()} \indexc{parse()} 
+\index{expression object} \indexc{expression()} \indexc{parse()}
 
 Finally, we need to briefly discuss the expression object. Expression objects are produced by only two base functions: `expression()` and `parse()`:
 
@@ -487,9 +487,9 @@ Conceptually, an expression object is just a list of expressions. The only diffe
 
 ### Exercises
 
-1.  Which two of the six types of atomic vector can't appear in an expression? 
-    Why? Why can't you create an expression that contains an atomic vector of 
-    length greater than one? 
+1.  Which two of the six types of atomic vector can't appear in an expression?
+    Why? Why can't you create an expression that contains an atomic vector of
+    length greater than one?
 
 1.  How is `rlang::maybe_missing()` implemented? Why does it work?
 
@@ -509,10 +509,10 @@ Conceptually, an expression object is just a list of expressions. The only diffe
     names(x) <- c("x", "")
     ```
 
-1.  Construct the expression `if(x > 1) "a" else "b"` using multiple calls to 
+1.  Construct the expression `if(x > 1) "a" else "b"` using multiple calls to
     `lang()`. How does the structure code reflect the structure of the AST?
 
-## Parsing and deparsing 
+## Parsing and deparsing
 
 Most of the time you type code into the console, and R takes care of turning the characters you've typed into an AST. But occasionally you have code stored in a string, and you want to parse it yourself. You can do so using `rlang::parse_expr()`:
 
@@ -578,13 +578,13 @@ Be careful when using the base R equivalent, `deparse()`: it returns a character
 1.  What happens if you attempt to parse an invalid expression? e.g. `"a +"`
     or `"f())"`.
 
-1.  `deparse()` produces vectors when the input is long. For example, the 
+1.  `deparse()` produces vectors when the input is long. For example, the
     following call produces a vector of length two:
 
     ```{r, eval = FALSE}
     expr <- expr(g(a + b + c + d + e + f + g + h + i + j + k + l + m +
       n + o + p + q + r + s + t + u + v + w + x + y + z))
-    
+
     deparse(expr)
     ```
 
@@ -593,14 +593,14 @@ Be careful when using the base R equivalent, `deparse()`: it returns a character
 1.  Why does `as.Date.default()` use `substitute()` and `deparse()`?
     Why does `pairwise.t.test()` use them? Read the source code.
 
-1.  `pairwise.t.test()` assumes that `deparse()` always returns a length one 
-    character vector. Can you construct an input that violates this expectation? 
-    What happens? 
+1.  `pairwise.t.test()` assumes that `deparse()` always returns a length one
+    character vector. Can you construct an input that violates this expectation?
+    What happens?
 
 ## Case study: Walking the AST with recursive functions {#ast-funs}
 \index{recursion!over ASTs}
 
-To conclude the chapter I'm going to pull together everything that you've learned about ASTs and use that knowledge to solve more complicated problems. The inspiration comes from the base codetools package, which provides two interesting functions: 
+To conclude the chapter I'm going to pull together everything that you've learned about ASTs and use that knowledge to solve more complicated problems. The inspiration comes from the base codetools package, which provides two interesting functions:
 
 * `findGlobals()` locates all global variables used by a function. This
   can be useful if you want to check that your function doesn't inadvertently
@@ -614,12 +614,12 @@ Getting all of the details of these functions correct is fiddly, so we won't exp
 
 * The __recursive case__ handles the nodes in the tree. Typically, you'll
   do something to each child of node, usually calling the recursive function
-  again, and then combine the results back together again. For expressions, 
+  again, and then combine the results back together again. For expressions,
   you'll need to handle calls and pairlists (function arguments).
-  
+
 * The __base case__ handles the leaves of the tree. The base cases ensure
-  that the function eventually terminates, by solving the simplest cases 
-  directly. For expressions, you need to handle symbols and constants in the 
+  that the function eventually terminates, by solving the simplest cases
+  directly. For expressions, you need to handle symbols and constants in the
   base case.
 
 To make this pattern easier to see, we'll need two helper functions. First we define `expr_type()` which will return "constant" for constant, "symbol" for symbols, "call", for calls, "pairlist" for pairlists, and the "type" of anything else:
@@ -647,8 +647,8 @@ We'll couple this with a wrapper around the switch function:
 
 ```{r}
 switch_expr <- function(x, ...) {
-  switch(expr_type(x), 
-    ..., 
+  switch(expr_type(x),
+    ...,
     stop("Don't know how to handle type ", typeof(x), call. = FALSE)  
   )
 }
@@ -658,14 +658,14 @@ With these two functions in hand, the basic template for any function that walks
 
 ```{r}
 recurse_call <- function(x) {
-  switch_expr(x, 
+  switch_expr(x,
     # Base cases
     symbol = ,
     constant = ,
-    
+
     # Recursive cases
     call = ,
-    pairlist = 
+    pairlist =
   )
 }
 ```
@@ -674,7 +674,7 @@ Typically, solving the base case is easy, so we'll do that first, then check the
 
 ### Finding F and T
 
-We'll start simple with a function that determines whether a function uses the logical abbreviations `T` and `F`: it will return `TRUE` if it finds a logical abbreviation, and `FALSE` otherwise. Using `T` and `F` is generally considered to be poor coding practice, and is something that `R CMD check` will warn about. 
+We'll start simple with a function that determines whether a function uses the logical abbreviations `T` and `F`: it will return `TRUE` if it finds a logical abbreviation, and `FALSE` otherwise. Using `T` and `F` is generally considered to be poor coding practice, and is something that `R CMD check` will warn about.
 
 Let's first compare the AST for `T` vs. `TRUE`:
 
@@ -687,7 +687,7 @@ ast(T)
 
 ```{r}
 logical_abbr_rec <- function(x) {
-  switch_expr(x, 
+  switch_expr(x,
     constant = FALSE,
     symbol = as_string(x) %in% c("F", "T")
   )
@@ -716,7 +716,7 @@ logical_abbr_rec <- function(x) {
     # Base cases
     constant = FALSE,
     symbol = as_string(x) %in% c("F", "T"),
-    
+
     # Recursive cases
     call = ,
     pairlist = purrr::some(x, logical_abbr_rec)
@@ -729,7 +729,7 @@ logical_abbr(function(x, na.rm = T) FALSE)
 
 ### Finding all variables created by assignment
 
-`logical_abbr()` is very simple: it only returns a single `TRUE` or `FALSE`. The next task, listing all variables created by assignment, is a little more complicated. We'll start simply, and then make the function progressively more rigorous. \indexc{find\_assign()} 
+`logical_abbr()` is very simple: it only returns a single `TRUE` or `FALSE`. The next task, listing all variables created by assignment, is a little more complicated. We'll start simply, and then make the function progressively more rigorous. \indexc{find\_assign()}
 
 We start by looking at the AST for assignment:
 
@@ -745,7 +745,7 @@ With that in hand we can start by implementing the base cases and providing a he
 
 ```{r}
 find_assign_rec <- function(x) {
-  switch_expr(x, 
+  switch_expr(x,
     constant = ,
     symbol = character()
   )  
@@ -774,7 +774,7 @@ find_assign_rec <- function(x) {
     # Base cases
     constant = ,
     symbol = character(),
-    
+
     # Recursive cases
     pairlist = flat_map_chr(as.list(x), find_assign_rec),
     call = {
@@ -816,7 +816,7 @@ find_assign({
 })
 ```
 
-What happens if we have nested calls to `<-`  Currently we only return the first. That's because when `<-` occurs we immediately terminate recursion. 
+What happens if we have nested calls to `<-`  Currently we only return the first. That's because when `<-` occurs we immediately terminate recursion.
 
 ```{r}
 find_assign({
@@ -835,7 +835,7 @@ find_assign_call <- function(x) {
     lhs <- character()
     children <- as.list(x)
   }
-  
+
   c(lhs, flat_map_chr(children, find_assign_rec))
 }
 
@@ -844,7 +844,7 @@ find_assign_rec <- function(x) {
     # Base cases
     constant = ,
     symbol = character(),
-    
+
     # Recursive cases
     pairlist = flat_map_chr(x, find_assign_rec),
     call = find_assign_call(x)
@@ -863,7 +863,7 @@ While the complete version of this function is quite complicated, it's important
     `logical_abbr_rec()` so that it ignores function calls that use `T` or `F`?
 
 1.  `logical_abbr()` works with expressions. It currently fails when you give it
-    a function. Why not? How could you modify `logical_abbr()` to make it 
+    a function. Why not? How could you modify `logical_abbr()` to make it
     work? What components of a function will you need to recurse over?
 
     ```{r, eval = FALSE}
@@ -873,7 +873,7 @@ While the complete version of this function is quite complicated, it's important
     logical_abbr(!!f)
     ```
 
-1.  Modify find assignment to also detect assignment using replacement 
+1.  Modify find assignment to also detect assignment using replacement
     functions, i.e. `names(x) <- y`.
-  
+
 1.  Write a function that extracts all calls to a specified function.


### PR DESCRIPTION
Section 21.4.4 (Expressions::Data_structures::Calls)

The text in this section referred to `rlang::lang_standardise` in two
locations. This function has been deprecated in `rlang` and renamed
`call_standardise`.

The exercises at the end of the 'Data structures' subsection use the function
call_standardise, so I updated the text to refer to call_standardise not
lang_standardise.

I assign the copyright of this contribution to Hadley Wickham