### PR TITLE
Change geometric distribution to number of failures before 1st success.

### DIFF
--- a/Functionals.Rmd
+++ b/Functionals.Rmd
@@ -920,7 +920,7 @@ while(TRUE) {
 
 This is a common problem when you're writing simulations.
 
-In this case we can remove the loop by recognising a special feature of the problem. Here we're counting the number of successes before Bernoulli trial with p = 0.1 fails. This is a geometric random variable, so you could replace the code with `i <- rgeom(1, 0.1)`. Reformulating the problem in this way is hard to do in general, but you'll benefit greatly if you can do it for your problem.
+In this case we can remove the loop by recognising a special feature of the problem. Here we're counting the number of failures before Bernoulli trial with p = 0.1 succeeds. This is a geometric random variable, so you could replace the code with `i <- rgeom(1, 0.1)`. Reformulating the problem in this way is hard to do in general, but you'll benefit greatly if you can do it for your problem.
 
 ## A family of functions {#function-family}
 


### PR DESCRIPTION
I realize the designation of success versus failure for a Bernoulli trial is arbitrary, but if `p` is defined as the probability of success, then I think this code is counting the number of failures before the first success. This is consistent with the [description of the geometric distribution](https://en.wikipedia.org/wiki/Geometric_distribution#Introduction_to_the_geometric_distribution) in Wikipedia:

> Consider a sequence of trials, where each trial has only two possible outcomes (designated failure and success). The probability of success is assumed to be the same for each trial. In such a sequence of trials, the geometric distribution is useful to model the number of failures before the first success. The distribution gives the probability that there are zero failures before the first success, one failure before the first success, two failures before the first success, and so on.

This is also my interpretation of the description of the geometric distribution from `?rgeom`:
```
x, q	vector of quantiles representing the number of failures in a sequence of Bernoulli trials before success occurs.
...
prob	probability of success in each trial. 0 < prob <= 1.
```

I assign the copyright of this contribution to Hadley Wickham.