### PR TITLE
Fix typos

### DIFF
--- a/beyond-exception-handling.Rmd
+++ b/beyond-exception-handling.Rmd
@@ -384,7 +384,7 @@ this function to establish a condition handler that invokes the
 `skip_log_entry` restart for you. However, you can't use `tryCatch()`
 to establish the condition handler because then the stack would be
 unwound to the function where the `tryCatch()` appears. Instead, you
-need to use the lower-level macro `withCallingHandlers()`. The basic form of
+need to use the function `withCallingHandlers()`. The basic form of
 `withCallingHandlers()` is as follows:
 
 ```{r, eval = FALSE}


### PR DESCRIPTION
Change "macro" (probably left over from the original Lisp version) to "function"