### PR TITLE
Fixing Typo in Names-values.Rmd

### DIFF
--- a/Names-values.Rmd
+++ b/Names-values.Rmd
@@ -593,7 +593,7 @@ for (i in 1:5) {
 #> tracemem[0x7f80c5c3de20 -> 0x7f80c48de210]: 
 ```
 
-While it's not hard to determine when copies are made, it is hard to preventing them. If you find yourself resorting to exotic tricks to avoid copies, it may be time to rewrite your function in C++, as described in Chapter \@ref(rcpp).
+While it's not hard to determine when copies are made, it is hard to prevent them. If you find yourself resorting to exotic tricks to avoid copies, it may be time to rewrite your function in C++, as described in Chapter \@ref(rcpp).
 
 ### Environments {#env-modify}
 


### PR DESCRIPTION
Changed "to preventing them" to "to prevent them"

I assign the copyright of this contribution to Hadley Wickham