### PR TITLE
Grammar corrected

### DIFF
--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -595,7 +595,7 @@ intercept <- 10
 coefs <- c(x1 = 5, x2 = -4)
 ```
 
-And you want to convert it into an expression like `10 + (5 * x1) + (-4 * x2)`. The first thing we need to turn is turn the character names vector into a list of symbols. `rlang::syms()` is designed precisely for this case:
+And you want to convert it into an expression like `10 + (5 * x1) + (-4 * x2)`. The first thing we need to do is turn the character names vector into a list of symbols. `rlang::syms()` is designed precisely for this case:
 
 ```{r}
 coef_sym <- syms(names(coefs))


### PR DESCRIPTION
Not sure if the expression was meant to be ‚as is’, since I am no native speaker.

Duckduckgoing "all we need to turn is turn" did not yield any result, giving me confidence it is meant to be as proposed here.

Please excuse inconvenience, if so, and thank you for the nice read!