### PR TITLE
explain that attr are lost on s3 classes, unless otherwise implemented

### DIFF
--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -209,7 +209,7 @@ There are three exceptions for particularly important attributes:
 
 * Names, a character vector giving each element a name.
 * Dimensions, an integer vector, used to turn vectors into matrices and arrays.
-* Class, a character vector, used to implement the S3 object system.
+* Class, a character vector, used to implement the S3 object system.^[The class attribute is still lost on vector operations, except when a special method of that operation has been implemented for the class in question.]
 
 Each of these three attributes is described in more detail below.
 
@@ -306,6 +306,9 @@ attr(x, "levels")
 
 attr(x[1], "levels")
 ```
+
+Factors keep their attributes on subsetting, because there is a special subsetting method *for* factors in base R (`'[.factor'()`/ `Extract.factor()`) which retains attributes.
+Without such a special method, factors would loose their attributes on subsetting just as any other S3 object.
 
 You'll learn the details of the S3 object system, and how to create your own S3 classes, in Chapter \@ref(s3). In the following section, you'll learn more about the most important S3 atomic vectors in base R.
 


### PR DESCRIPTION
In `Vectors.Rmd`:

> Attributes should generally be thought of as ephemeral (unless they’re formalised into an S3 class). For example, most attributes will be lost when you operate on a vector:
>
> ```
> attributes(a[1])
> #> NULL
>
> attributes(sum(a))
> #> NULL
> ```
>
> There are three exceptions for particularly important attributes:
>
> - Names, a character vector giving each element a name.
> - Dimensions, an integer vector, used to turn vectors into matrices and arrays.
> - Class, a character vector, used to implement the S3 object system.

From this, I initially got the impression that 
- class attributes are *always* retained on vector operations, or even that 
- for S3 objects, *all* attributes are retained
  > Attributes should generally be thought of as ephemeral (unless they’re formalised into an S3 class)

But that isn't so:

```
x <- structure(
  .Data = c("zap", "zong"),
  class = c("myClass", "character")
)
x
#> [1] "zap"  "zong"
#> attr(,"class")
#> [1] "myClass"   "character"

attributes(x[1])
#> NULL
```

I only understood later (when reading about `sloop::reconstruct()`), that attribute retention for factors *only* works because there is a special method `'[.factor'()`.

Perhaps other people might stumble across this as well.