### PR TITLE
Mention enquos() rather than quos()

### DIFF
--- a/Functions.Rmd
+++ b/Functions.Rmd
@@ -764,7 +764,7 @@ i04 <- function(...) {
 str(i04(a = 1, b = 2))
 ```
 
-(See also `rlang::list2()` to support splicing and to silently ignore trailing commas, and `rlang::quos()` to capture the unevaluated arguments, the topic of [quasiquotation].)
+(See also `rlang::list2()` to support splicing and to silently ignore trailing commas, and `rlang::enquos()` to capture the unevaluated arguments, the topic of [quasiquotation].)
 
 There are two primary uses of `...`, both of which we'll come back to later in the book:
 


### PR DESCRIPTION
Since `enquos()` is now the recommended way to capture dots.