### PR TITLE
Switch users' to singular possessive

### DIFF
--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -156,7 +156,7 @@ The first part of quasiquotation is quotation: capturing an AST without evaluati
 
 ### With rlang
 
-There are four important quoting functions, broken down by whether they capture one or many expressions, and whether they capture the developer's or users' expression:
+There are four important quoting functions, broken down by whether they capture one or many expressions, and whether they capture the developer's or user's expression:
 
 |      | Developer | User        |
 |------|-----------|-------------|


### PR DESCRIPTION
You use "the user" (singular) as the section continues, so I think it makes more sense this way.

Bonus fun fact: 'twas the only place you used "users'" in the whole book. 🕴