### PR TITLE
Add RStudio Community to "getting help"

### DIFF
--- a/Introduction.Rmd
+++ b/Introduction.Rmd
@@ -27,7 +27,7 @@ If you are new to R, you might wonder what makes learning such a quirky language
 
 * A fantastic community. It is easy to get help from experts on the
   [R-help mailing list](https://stat.ethz.ch/mailman/listinfo/r-help),
-  [stackoverflow](http://stackoverflow.com/questions/tagged/r),
+  [stackoverflow](http://stackoverflow.com/questions/tagged/r), [RStudio Community](https://community.rstudio.com/),
   or subject-specific mailing lists like
   [R-SIG-mixed-models](https://stat.ethz.ch/mailman/listinfo/r-sig-mixed-models)
   or [ggplot2](https://groups.google.com/forum/#!forum/ggplot2). You
@@ -151,7 +151,7 @@ If you want to learn to be a better programmer, there's no place better to turn 
 
 ## Getting help {#getting-help}
 
-Currently, there are two main venues to get help when you're stuck and can't figure out what's causing the problem: [stackoverflow](http://stackoverflow.com) and the R-help mailing list. You can get fantastic help in both venues, but they do have their own cultures and expectations. It's usually a good idea to spend a little time lurking, learning about community expectations, before you put up your first post. \index{help}
+Currently, there are three main venues to get help when you're stuck and can't figure out what's causing the problem: [RStudio Community](https://community.rstudio.com/), [stackoverflow](http://stackoverflow.com) and the R-help mailing list. You can get fantastic help in each venue, but they do have their own cultures and expectations. It's usually a good idea to spend a little time lurking, learning about community expectations, before you put up your first post. \index{help}
 
 Some good general advice:
 
@@ -162,7 +162,10 @@ Some good general advice:
 * Spend some time creating a
   [reproducible example](http://stackoverflow.com/questions/5963269). This
   is often a useful process in its own right, because in the course of making
-  the problem reproducible you often figure out what's causing the problem.
+  the problem reproducible you often figure out what's causing the problem. 
+  The [`reprex`](https://reprex.tidyverse.org/) package can help you create a 
+  **repr**oducible **ex**ample that will can easily be run by people trying to help you. 
+  There are [several resources available](https://community.rstudio.com/t/faq-whats-a-reproducible-example-reprex-and-how-do-i-do-one/5219) to help you create a successful `reprex`.
 
 * Look for related problems before posting. If someone has already asked
   your question and it has been answered, it's much faster for everyone if you


### PR DESCRIPTION
I added references to RStudio Community in the "Getting Help" section and added two sentences about using the `reprex` package to the bullet point about creating a reproducible example.