### PR TITLE
Update new_subclass constructor in S3 chapter

### DIFF
--- a/S3.Rmd
+++ b/S3.Rmd
@@ -640,7 +640,7 @@ Then the implementation of the subclass constructor is simple: it checks the typ
 ```{r}
 new_subclass <- function(x, y, z) {
   stopifnot(is.character(z))
-  new_my_class(x, y, z, subclass = "subclass")
+  new_my_class(x, y, z = z, subclass = "subclass")
 }
 ```
 


### PR DESCRIPTION
Change `z` argument to be named argument: `z = z`

I assign the copyright of this contribution to Hadley Wickham