### PR TITLE
Fix a description about double dispatch when the methods are different

### DIFF
--- a/S3.Rmd
+++ b/S3.Rmd
@@ -886,7 +886,7 @@ If `+` dispatched only on the first argument, it would return different values f
 
 * The methods are the same, so it doesn't matter which method is used.
 
-* The methods are different, and R calls the first method with a warning.
+* The methods are different, and R falls back to the internal method with a warning.
 
 * One method is internal, in which case R calls the other method.
 


### PR DESCRIPTION
Fix #1195 

If both `a` and `b` are S3 objects, the method chosen in `a + b` can be:

| Does `a` have an S3 method | Does `b` have an S3 method | Are the methods same? | Whet method is chosen? |
|:-------------|:--------------|:-------|:------------|
| yes | yes | yes | `a`'s method or `b`'s method (they are the same) |
| yes | yes | no | internal method |
| yes | no | - | `a`'s method |
| no | yes | - | `b`'s method |
| no | no | - | internal method |

c.f. https://gist.github.com/yutannihilation/1c227c6d662c991cc2c66ca146de80ea

So, this should be summarised as following:

*    The methods are the same, so it doesn’t matter which method is used.
*    The methods are different, and **R falls back to the internal method with a warning.**
*    One method is internal, in which case R calls the other method.
