### PR TITLE
Add missing words in FP intro

### DIFF
--- a/FP.Rmd
+++ b/FP.Rmd
@@ -9,7 +9,7 @@ source("common.R")
 
 R, at its heart, is a __functional__ language. This means that it has certain technical properties, but more importantly that it lends itself to a style of problem solving centered on functions. Below I'll give a brief overview of the technical definition of a functional _language_, but in this book I will primarily focus on the functional _style_ of programming, because I think it is an extremely good fit to the types of problem you commonly encounter when doing data analysis.
 
-Recently, functional techniques have experienced a surge in interest because can produce efficient and elegant solutions to many modern problems. A functional style tends to create functions that can easily be analysed in isolation (i.e. using only local information), and hence often much easier to automatically optimise or parallelise. The traditional weaknesses of function languages, poorer performance and sometimes unpredictable memory usage, have been much reduced in recent years. Functional programming is complementary to object oriented programming, which has been the dominant programming paradigm for the last several decades. 
+Recently, functional techniques have experienced a surge in interest because they can produce efficient and elegant solutions to many modern problems. A functional style tends to create functions that can easily be analysed in isolation (i.e. using only local information), and hence is often much easier to automatically optimise or parallelise. The traditional weaknesses of function languages, poorer performance and sometimes unpredictable memory usage, have been much reduced in recent years. Functional programming is complementary to object oriented programming, which has been the dominant programming paradigm for the last several decades. 
 
 ## Functional programming languages {-}
 
@@ -27,9 +27,9 @@ Secondly, many functional languages require functions to be __pure__. A function
   writing to disk, or displaying to the screen. This excludes functions like
   `print()`, `write.csv()` and `<-`.
 
-Pure functions are much easier to reason because about but obviously have significant downsides: imagine doing a data analysis where you couldn't generate random numbers or read files from disk. 
+Pure functions are much easier to reason about, but obviously have significant downsides: imagine doing a data analysis where you couldn't generate random numbers or read files from disk. 
 
-Strictly speaking, R isn't a functional programming _language_ because it doesn't require that you write pure functions. However, you can certainly adopt a functional style in parts of your code: you don't _have_ to write pure functions, but you often _should_. In my experience, partitioning code into functions that either extremely pure and or extremely impure tends to lead to code that is easier to understand and extend to new situations.
+Strictly speaking, R isn't a functional programming _language_ because it doesn't require that you write pure functions. However, you can certainly adopt a functional style in parts of your code: you don't _have_ to write pure functions, but you often _should_. In my experience, partitioning code into functions that are either extremely pure and or extremely impure tends to lead to code that is easier to understand and extend to new situations.
 
 ## Functional style {-}
 


### PR DESCRIPTION
n.b. I added the _is_ in https://github.com/batpigandme/adv-r/commit/a7cf4b0a25fcf1f972104926b290917a66d3d888#diff-ed8b1340d157a79b8555ae20e0459f2fR12
> A functional style tends to create functions that can easily be analysed in isolation (i.e. using only local information), and hence _**is**_ often much easier to automatically optimise or parallelise.

It's possible that the _is_ should be _are_ and the subject is _functions_ and not _A functional style_, but either way, I think there should be a verb there.