### PR TITLE
Replace `lang()` with `call2()`

### DIFF
--- a/Expressions.Rmd
+++ b/Expressions.Rmd
@@ -415,11 +415,11 @@ x$header <- TRUE
 x
 ```
 
-You can construct a call from its children by using `rlang::lang()`. The first argument should be the function to be called (supplied either as a string or a symbol), and the subsequent arguments are the call to that function:
+You can construct a call from its children by using `rlang::call2()`. The first argument should be the function to be called (supplied either as a string or a symbol), and the subsequent arguments are the call to that function:
 
 ```{r}
-lang("mean", x = expr(x), na.rm = TRUE)
-lang(expr(mean), x = expr(x), na.rm = TRUE)
+call2("mean", x = expr(x), na.rm = TRUE)
+call2(expr(mean), x = expr(x), na.rm = TRUE)
 ```
 
 ### Pairlists
@@ -510,7 +510,7 @@ Conceptually, an expression object is just a list of expressions. The only diffe
     ```
 
 1.  Construct the expression `if(x > 1) "a" else "b"` using multiple calls to 
-    `lang()`. How does the code structure reflect the structure of the AST?
+    `call2()`. How does the code structure reflect the structure of the AST?
 
 ## Parsing and deparsing 
 


### PR DESCRIPTION
* Since `rlang::lang()` is soft-deprecated and gives warning instructing to switch to `call2()`