### PR TITLE
Hyphenate first-class environments

### DIFF
--- a/FP.Rmd
+++ b/FP.Rmd
@@ -15,7 +15,7 @@ Recently, functional techniques have experienced a surge in interest because the
 
 Every programming language has functions, so what makes a programming language functional? There are many defintions for precisely what makes a language "functional", but there are two common threads. 
 
-Firstly, functional languages have __first class functions__, functions that behave like any other data structure. In R, this means that you can do anything with a function that you can do with a vector: you can assign them to variables, store them in lists, pass them as arguments to other functions, create them inside functions, and even return them as the result of a function. 
+Firstly, functional languages have __first-class functions__, functions that behave like any other data structure. In R, this means that you can do anything with a function that you can do with a vector: you can assign them to variables, store them in lists, pass them as arguments to other functions, create them inside functions, and even return them as the result of a function. 
 
 Secondly, many functional languages require functions to be __pure__. A function is pure if it satisfies two properties:
 

--- a/Function-factories.Rmd
+++ b/Function-factories.Rmd
@@ -31,7 +31,7 @@ cube(3)
 
 You have already learned about the individual components that make function factories possible:
 
-* In Section \@ref(first-class-functions), you learned about R's "first class" 
+* In Section \@ref(first-class-functions), you learned about R's "first-class" 
   functions. In R, you bind a function to a name in the same way as you bind
   any object to a name: with `<-`.
 
@@ -68,7 +68,7 @@ Of the three main functional programming tools (functionals, function factories,
 
 ### Prerequisites {-}
 
-Make sure you're familiar with the contents of Sections \@ref(first-class-functions) (first class functions), \@ref(the-function-environment) (function environments), and \@ref(execution-environments) (execution environments) mentioned above.
+Make sure you're familiar with the contents of Sections \@ref(first-class-functions) (first-class functions), \@ref(the-function-environment) (function environments), and \@ref(execution-environments) (execution environments) mentioned above.
 
 Function factories only need base R. We'll use a little rlang to peek inside of them more easily, and we'll use ggplot2 and scales to explore the use of function factories in visualisation.
 

--- a/Meta.Rmd
+++ b/Meta.Rmd
@@ -90,7 +90,7 @@ In the following chapters, you'll learn about the three big ideas that underpin 
   write your own functions that work like `subset()`.
 
 * Finally, in __Translating R code__, [Translation](#translation), you'll see how to combine
-  first class environments, lexical scoping, and metaprogramming to translate R
+  first-class environments, lexical scoping, and metaprogramming to translate R
   code into other languages, namely HTML and LaTeX.
 
 Each chapter follows the same basic structure. You'll get the lay of the land in introduction, then see a motivating example. Next you'll learn the big ideas using functions from rlang, and then we'll circle back to talk about how those ideas are expressed in base R. Each chapter finishes with a case study, using the ideas to solve a bigger problem.

--- a/Translation.Rmd
+++ b/Translation.Rmd
@@ -7,7 +7,7 @@ library(dbplyr) # to supress startup messages below
 
 ## Introduction
 
-The combination of first class environments, lexical scoping, and metaprogramming gives us a powerful toolkit for translating R code into other languages. One fully-fledged example of this idea is dbplyr. dbplyr powers the database backends for dplyr, allowing us to express data maniplation in R and automatically translating it into SQL. An important part of dbplyr is `translate_sql()` which turns vector R code in to the equivalent SQL:
+The combination of first-class environments, lexical scoping, and metaprogramming gives us a powerful toolkit for translating R code into other languages. One fully-fledged example of this idea is dbplyr. dbplyr powers the database backends for dplyr, allowing us to express data maniplation in R and automatically translating it into SQL. An important part of dbplyr is `translate_sql()` which turns vector R code in to the equivalent SQL:
 
 ```{r}
 library(dbplyr)


### PR DESCRIPTION
I left `first class function(s)`, but modified to compound modifier for env't(s). (IMHO, first-class functions should get a hyphen, too. Just LMK). 😳 