### PR TITLE
Fixes two typos

### DIFF
--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -187,7 +187,7 @@ You might have noticed that the set of atomic vectors does not include a number 
 
 You can think of attributes as a named list[^pairlist] used to attach metadata to an object. Individual attributes can be retrieved and modified with `attr()`, or retrieved en masse with `attributes()`, and set en masse with `structure()`. 
 
-[^pairlist]: The reality is a little more complicated: attributes are actually stored in pairlists. Pairlists are functionally indistinguisable from lists, but are profoundly different under the hood, and you'll learn more about them in Section \@ref(pairlists). 
+[^pairlist]: The reality is a little more complicated: attributes are actually stored in pairlists. Pairlists are functionally indistinguishable from lists, but are profoundly different under the hood, and you'll learn more about them in Section \@ref(pairlists). 
 
 ```{r}
 a <- 1:3
@@ -571,7 +571,7 @@ typeof(df1)
 attributes(df1)
 ```
 
-[^rownames]: Row names are one of the most suprisingly complex data structures in R, because they've been a persistent performance issue over many years. The most straightforward representations are character or integer vectors, with one element for each row. There's also a compact representation for "automatic" row names (consecutive integers), created by `.set_row_names()`. R 3.5 has a special way of deferring integer to character conversions specifically to speed up `lm()`; see <https://svn.r-project.org/R/branches/ALTREP/ALTREP.html#deferred_string_conversions> for details.
+[^rownames]: Row names are one of the most surprisingly complex data structures in R, because they've been a persistent performance issue over many years. The most straightforward representations are character or integer vectors, with one element for each row. There's also a compact representation for "automatic" row names (consecutive integers), created by `.set_row_names()`. R 3.5 has a special way of deferring integer to character conversions specifically to speed up `lm()`; see <https://svn.r-project.org/R/branches/ALTREP/ALTREP.html#deferred_string_conversions> for details.
 
 Because each element of the list has the same length, data frames have a rectangular structure, and hence shares properties of both the matrix and the list:
 


### PR DESCRIPTION
indistinguisable -> indistinguishable
suprisingly -> surprisingly

I assign the copyright of this contribution to Hadley Wickham