### PR TITLE
Typo: allows -> always

### DIFF
--- a/S3.Rmd
+++ b/S3.Rmd
@@ -686,7 +686,7 @@ x2 <- new_supersecret(c(15, 1, 456))
 x2
 ```
 
-To allow inheritance, you also need to think carefully about your methods, as you can no longer use the constructor. If you do, the method will allows return the same class, regardless of the input. The forces whoever makes a subclass do a lot of extra work. 
+To allow inheritance, you also need to think carefully about your methods, as you can no longer use the constructor. If you do, the method will always return the same class, regardless of the input. The forces whoever makes a subclass do a lot of extra work. 
 
 Concretely, that means we need to revise the `[.secret` method. Currently it always returns a `secret()`, even when given a supersecret:
 


### PR DESCRIPTION
This PR corrects a trivial typo: `allows` -> `always` as the intention of the sentence seems to be:

> If you do, the method will always return the same class, regardless of the input.