### PR TITLE
Copy edit S3 chapter

### DIFF
--- a/S3.Rmd
+++ b/S3.Rmd
@@ -8,7 +8,7 @@ source("common.R")
 \index{S3} 
 \index{objects!S3|see{S3}} 
 
-S3 is R's first and simplest OO system. S3 is informal and ad hoc, but there is a certain elegance in its minimalism: you can't take away any part of it and still have a useful OO system. For these reasons, you should use it unless you have a compelling reason to do otherwise. S3 is the only OO system used in the base and stats packages, and it's the most commonly used system in CRAN packages. \index{S3} \index{objects!S3|see{S3}}
+S3 is R's first and simplest OO system. S3 is informal and ad hoc, but there is a certain elegance in its minimalism: you can't take away any part of it and still have a useful OO system. For these reasons, you should use it, unless you have a compelling reason to do otherwise. S3 is the only OO system used in the base and stats packages, and it's the most commonly used system in CRAN packages. \index{S3} \index{objects!S3|see{S3}}
 
 S3 is very flexible, which means it allows you to do things that are quite ill-advised. If you're coming from a strict environment like Java this will seem pretty frightening, but it gives R programmers a tremendous amount of freedom.  It may be very difficult to prevent someone from doing something you don't want them to do, but your users will never be held back because there is something you haven't implemented yet. Since S3 has few built-in constraints, the key to its successful use is applying the constraints yourself. This chapter will therefore teach you the conventions you should (almost) always adhere to.
 
@@ -68,7 +68,7 @@ You can get the "underlying" base type by `unclass()`ing it, which strips the cl
 unclass(f)
 ```
 
-An S3 object behaves differently from its underlying base type whenever it's passed to a __generic__ (short for generic function). The easiest way to tell if a function is generic is to use `sloop::ftype()` and look for "generic" in the output:
+An S3 object behaves differently from its underlying base type whenever it's passed to a __generic__ (short for generic function). The easiest way to tell if a function is a generic is to use `sloop::ftype()` and look for "generic" in the output:
 
 ```{r}
 ftype(print)
@@ -220,7 +220,7 @@ You don't need a validator for very simple classes, and you can skip the helper 
 
 S3 doesn't provide a formal definition of a class, so it has no built-in way to ensure that all objects of a given class have the same structure (i.e. the same base type and the same attributes with the same types). Instead, you must enforce a consistent structure yourself by using a __constructor__.
 
-The constructor should three principles:
+The constructor should follow three principles:
 
 * Be called `new_myclass()`.
 
@@ -241,7 +241,7 @@ new_Date <- function(x = double()) {
 new_Date(c(-1, 0, 1))
 ```
 
-The purpose of the constructor is to help you, the developer. That means you can keep them simple, and you don't need to optimise error messages for public consumption. If you expect users to also create objects, you should create a friendly helper function, called `class_name()`, which I'll describe shortly.
+The purpose of constructors is to help you, the developer. That means you can keep them simple, and you don't need to optimise error messages for public consumption. If you expect users to also create objects, you should create a friendly helper function, called `class_name()`, which I'll describe shortly.
 
 A slightly more complicated constructor is that for `difftime`, which is used to represent time differences. It is again built on a double, but has a units attribute that must take one of a small set of values:
 
@@ -310,7 +310,7 @@ validate_factor(new_factor(1:5, "a"))
 validate_factor(new_factor(0:1, "a"))
 ```
 
-This function is called primarily for its side-effects (throwing an error if the object is invalid) so you'd expect it to invisibly return its primary input (as described in Section \ref(invisible)). However, it's useful for validation methods to return visibly, as we'll see next.
+This validator function is called primarily for its side-effects (throwing an error if the object is invalid) so you'd expect it to invisibly return its primary input (as described in Section \ref(invisible)). However, it's useful for validation methods to return visibly, as we'll see next.
 
 ### Helpers
 
@@ -349,7 +349,7 @@ The last bullet is the trickiest, and it's hard to give general advice. However,
     ```
     
 *   Often, the most natural representation of a complex object is a string.
-    For example, it's very convenient to specify factors with a character   
+    For example, it's very convenient to specify factors with a character 
     vector. The code below shows a simple version of `factor()`: it takes a
     character vector, and guesses that the levels should the unique values. 
     This is not always correct (since some levels might not be seen in the 
@@ -413,7 +413,7 @@ For more complicated classes, you should feel free to go beyond these patterns t
 \indexc{UseMethod()} 
 \index{S3!new generic}
 
-The job of an S3 generic is to perform method dispatch, i.e. find the specific implementation for a class. Method dispatch is performed by `UseMethod()`, which every generic calls[^internal-generic]. `UseMethod()` takes two arguments: the name of the generic function (required), and the argument to use for method dispatch (optional). If you omit the second argument it will dispatch based on the first argument, which is almost always what is desired.
+The job of an S3 generic is to perform method dispatch, i.e. find the specific implementation for a class. Method dispatch is performed by `UseMethod()`, which every generic calls[^internal-generic]. `UseMethod()` takes two arguments: the name of the generic function (required), and the argument to use for method dispatch (optional). If you omit the second argument, it will dispatch based on the first argument, which is almost always what is desired.
 
 [^internal-generic]: The exception is internal generics, which are implemented in C, and are the topic of Section \@ref(internal-generics).
 
@@ -449,7 +449,7 @@ The output here is simple:
 * `=>` indicates the method that is called, here `print.Date()`
 * `*` indicates a method that is defined, but not called, here `print.default()`.
 
-The "default" class is a special __pseudo-class__. This is not a real class, but is included to make it possible to define a standard fallback that is found whenever a class specific method is not available.
+The "default" class is a special __pseudo-class__. This is not a real class, but is included to make it possible to define a standard fallback that is found whenever a class-specific method is not available.
 
 The essence of method dispatch is quite simple, but as the chapter proceeds you'll see it get progressively more complicated to encompass inheritance, base types, internal generics, and group generics. The code below shows a couple of more complicated cases which we'll come back to in Sections \@ref(inheritance) and \@ref(s3-dispatch). 
 
@@ -629,7 +629,7 @@ Note that `POSIXt` does not adhere to these principles becase `POSIXct` has type
 
 ### `NextMethod()`
 
-`NextMethod()` is the hardest part of inheritance to understand so we'll start with a concrete example for the most common use case: `[`.  We'll start by creating a simple toy class: a `secret` class that hides its output when printed:
+`NextMethod()` is the hardest part of inheritance to understand, so we'll start with a concrete example for the most common use case: `[`.  We'll start by creating a simple toy class: a `secret` class that hides its output when printed:
 
 ```{r}
 new_secret <- function(x = double()) {
@@ -724,7 +724,7 @@ x2 <- new_supersecret(c(15, 1, 456))
 x2
 ```
 
-To allow inheritance, you also need to think carefully about your methods, as you can no longer use the constructor. If you do, the method will always return the same class, regardless of the input. The forces whoever makes a subclass do a lot of extra work. 
+To allow inheritance, you also need to think carefully about your methods, as you can no longer use the constructor. If you do, the method will always return the same class, regardless of the input. This forces whoever makes a subclass to do a lot of extra work. 
 
 Concretely, this means we need to revise the `[.secret` method. Currently it always returns a `secret()`, even when given a supersecret:
 
@@ -738,7 +738,7 @@ x2[1:3]
 
 We want to make sure that `[.secret` returns the same class as `x` even if it's a subclass. As far as I can tell, there is no way to solve this problem using base R alone. Instead, you'll need to use the vctrs package, which provides a solution in the form of the `vctrs::vec_restore()` generic. This generic takes two inputs: a object which has lost subclass information, and a template object to use for restoration.
 
-Typically `vec_restore()` method are quite simple: you'll just call the constructor with appropriate arguments:
+Typically `vec_restore()` methods are quite simple: you just call the constructor with appropriate arguments:
 
 ```{r}
 vec_restore.secret <- function(x, to) new_secret(x)


### PR DESCRIPTION
Minor changes listed below in order of appearance (in case they're ambiguous):

* Missing comma
* Use "a generic" as you do elsewhere
* Missing word
* Subject agreement between two sentences
* Reiterating that it's about validators
* Errant line break
* Conditional comma
* Compound modifier  
* Added comma  
* Missing word  
* Stay in tense  