### PR TITLE
Suggestion: explain function diagrams…

### DIFF
--- a/Functions.Rmd
+++ b/Functions.Rmd
@@ -85,11 +85,84 @@ Answer the following questions to see if you can safely skip this chapter. You c
 
 To understand functions in R you need to internalise two important ideas:
 
-* Functions are objects, just as vectors are objects.
-
 * Functions can be broken down into three components: arguments, body, and environment.
 
 There are exceptions to every rule, and in this case, there is a small selection of "primitive" base functions that are implemented purely in C.
+
+* Functions are objects, just as vectors are objects.
+
+### Function components
+\index{functions!body} 
+\indexc{body()} 
+\index{functions!formals} 
+\indexc{formals()} 
+\index{functions!environment}
+\index{environments!of a function}
+
+A function has three parts: 
+
+* The `formals()`, the list of arguments that control how you call the function.
+  
+* The `body()`, the code inside the function.
+
+* The `environment()`, the data structure that determines how the function finds 
+the values associated with the names.
+
+While the formals and body are specified explicitly when you create a function, the environment is specified implicitly, based on _where_ you defined the function. The function environment always exists, but it is only printed when the function isn't defined in the global environment.
+
+```{r}
+f02 <- function(x, y) {
+  # A comment
+  x + y
+}
+
+formals(f02)
+
+body(f02)
+
+environment(f02)
+```
+
+I'll draw functions as in the following diagram. The black dot on the left is the environment. The two blocks to the right are the function arguments. I won't draw the body, because it's usually large, and doesn't help you understand the "shape" of the function.
+
+```{r, echo = FALSE, out.width = NULL}
+knitr::include_graphics("diagrams/functions/components.png")
+```
+
+Like all objects in R, functions can also possess any number of additional `attributes()`. One attribute used by base R is "srcref", short for source reference. It points to the source code used to create the function. The srcref is used for printing because, unlike `body()`, it contains code comments and other formatting.  
+
+```{r}
+attr(f02, "srcref")
+```
+
+### Primitive functions
+\index{primitive functions} 
+\index{functions!primitive|see{primitive functions}} 
+\indexc{.Primitive}
+
+There is one exception to the rule that a function has three components. Primitive functions, like `sum()` and `[`, call C code directly. 
+
+```{r}
+sum
+`[`
+```
+
+They have type "builtin" or "special":
+
+```{r}
+typeof(sum)
+typeof(`[`)
+```
+
+These functions exist primarily in C, not R, so their `formals()`, `body()`, and `environment()` are all `NULL`:  
+
+```{r}
+formals(sum)
+body(sum)
+environment(sum)
+```
+
+Primitive functions are only found in the base package. While they have certain performance advantages, this benefit comes at a price: they are harder to write. For this reason, R-core generally avoids creating them unless there is no other option.
 
 ### First-class functions {#first-class-functions}
 
@@ -134,79 +207,6 @@ typeof(f01)
 ```
 
 <!-- GVW: move this mention of closures down to the discussion of environments? Feels dangling here -->
-
-### Function components
-\index{functions!body} 
-\indexc{body()} 
-\index{functions!formals} 
-\indexc{formals()} 
-\index{functions!environment}
-\index{environments!of a function}
-
-A function has three parts: 
-
-* The `formals()`, the list of arguments that control how you call the function.
-  
-* The `body()`, the code inside the function.
-
-* The `environment()`, the data structure that determines how the function finds 
-the values associated with the names.
-
-I'll draw functions as in the following diagram. The black dot on the left is the environment. The two blocks to the right are the function arguments. I won't draw the body, because it's usually large, and doesn't help you understand the "shape" of the function.
-
-```{r, echo = FALSE, out.width = NULL}
-knitr::include_graphics("diagrams/functions/components.png")
-```
-
-While the formals and body are specified explicitly when you create a function, the environment is specified implicitly, based on _where_ you defined the function. The function environment always exists, but it is only printed when the function isn't defined in the global environment.
-
-```{r}
-f02 <- function(x) {
-  # A comment
-  x ^ 2
-}
-
-formals(f02)
-
-body(f02)
-
-environment(f02)
-```
-
-Like all objects in R, functions can also possess any number of additional `attributes()`. One attribute used by base R is "srcref", short for source reference. It points to the source code used to create the function. The srcref is used for printing because, unlike `body()`, it contains code comments and other formatting.  
-
-```{r}
-attr(f02, "srcref")
-```
-
-### Primitive functions
-\index{primitive functions} 
-\index{functions!primitive|see{primitive functions}} 
-\indexc{.Primitive}
-
-There is one exception to the rule that a function has three components. Primitive functions, like `sum()` and `[`, call C code directly. 
-
-```{r}
-sum
-`[`
-```
-
-They have type "builtin" or "special":
-
-```{r}
-typeof(sum)
-typeof(`[`)
-```
-
-These functions exist primarily in C, not R, so their `formals()`, `body()`, and `environment()` are all `NULL`:  
-
-```{r}
-formals(sum)
-body(sum)
-environment(sum)
-```
-
-Primitive functions are only found in the base package. While they have certain performance advantages, this benefit comes at a price: they are harder to write. For this reason, R-core generally avoids creating them unless there is no other option.
 
 ### Exercises
 

--- a/Functions.Rmd
+++ b/Functions.Rmd
@@ -101,6 +101,8 @@ f01 <- function(x) {
 }
 ```
 
+I'll draw functions as in the following diagram. The black dot on the left is the environment. The block to the right is the function argument. I won't draw the body, because it's usually large, and doesn't help you understand the "shape" of the function.
+
 ```{r, echo = FALSE, out.width = NULL}
 knitr::include_graphics("diagrams/functions/first-class.png")
 ```
@@ -151,12 +153,6 @@ A function has three parts:
 
 * The `environment()`, the data structure that determines how the function finds 
 the values associated with the names.
-
-I'll draw functions as in the following diagram. The black dot on the left is the environment. The two blocks to the right are the function arguments. I won't draw the body, because it's usually large, and doesn't help you understand the "shape" of the function.
-
-```{r, echo = FALSE, out.width = NULL}
-knitr::include_graphics("diagrams/functions/components.png")
-```
 
 While the formals and body are specified explicitly when you create a function, the environment is specified implicitly, based on _where_ you defined the function. The function environment always exists, but it is only printed when the function isn't defined in the global environment.
 

--- a/Functions.Rmd
+++ b/Functions.Rmd
@@ -101,8 +101,6 @@ f01 <- function(x) {
 }
 ```
 
-I'll draw functions as in the following diagram. The black dot on the left is the environment. The block to the right is the function argument. I won't draw the body, because it's usually large, and doesn't help you understand the "shape" of the function.
-
 ```{r, echo = FALSE, out.width = NULL}
 knitr::include_graphics("diagrams/functions/first-class.png")
 ```
@@ -153,6 +151,12 @@ A function has three parts:
 
 * The `environment()`, the data structure that determines how the function finds 
 the values associated with the names.
+
+I'll draw functions as in the following diagram. The black dot on the left is the environment. The two blocks to the right are the function arguments. I won't draw the body, because it's usually large, and doesn't help you understand the "shape" of the function.
+
+```{r, echo = FALSE, out.width = NULL}
+knitr::include_graphics("diagrams/functions/components.png")
+```
 
 While the formals and body are specified explicitly when you create a function, the environment is specified implicitly, based on _where_ you defined the function. The function environment always exists, but it is only printed when the function isn't defined in the global environment.
 

--- a/Functions.Rmd
+++ b/Functions.Rmd
@@ -166,7 +166,7 @@ Primitive functions are only found in the base package. While they have certain 
 
 ### First-class functions {#first-class-functions}
 
-The most important thing to understand about R is that functions are objects in their own right, a language property often called "first-class functions". Unlike in many other languages, there is no special syntax for defining and naming a function: you simply create a function object (with `function`) and bind it to a name with `<-`:
+It's very important to understand that R functions are objects in their own right, a language property often called "first-class functions". Unlike in many other languages, there is no special syntax for defining and naming a function: you simply create a function object (with `function`) and bind it to a name with `<-`:
 
 ```{r}
 f01 <- function(x) {


### PR DESCRIPTION
… as soon as we get to see the first such diagram.

As a reader, I felt that things didn't flow very well when I was first exposed to a function diagram without explanation as to what the black dot represented, then I finally got this explanation in the next section with a diagram for a function with 2 arguments while we haven't talked about any function with `x` and `y`.

I felt that moving the explanation up to the first diagram and removing the 2nd one which does not add anything (at least, this is how I felt as a reader) might make for a better flow through the section.

This is obviously only a suggestion, not a problem. So feel free to disagree and reject the PR!