### PR TITLE
Suggest expression change

### DIFF
--- a/Functionals.Rmd
+++ b/Functionals.Rmd
@@ -81,7 +81,7 @@ library(purrr)
 \indexc{map()}
 \indexc{lapply()}
 
-The most fundamental functional is `purrr::map()`[^Map]. It takes a vector and a function, calls the function once for each element of the vector, and returns the results in a list. In other words, `map(1:3, f)` is equivalent to `list(f(x[[1]]), f(x[[2]]), f(x[[3]]))`. 
+The most fundamental functional is `purrr::map()`[^Map]. It takes a vector and a function, calls the function once for each element of the vector, and returns the results in a list. In other words, `map(1:3, f)` is equivalent to `list(f(1), f(2), f(3))`. 
 
 ```{r}
 triple <- function(x) x * 3


### PR DESCRIPTION
Since `x` has not be defined, `list(f(1), f(2), f(3))` is clearer

If keeping `list(f(x[[1]]), f(x[[2]]), f(x[[3]]))` is important, then it might be
good to define `x <- 1:3` just before