### PR TITLE
Change reference link to cppreference

### DIFF
--- a/Rcpp.Rmd
+++ b/Rcpp.Rmd
@@ -22,7 +22,7 @@ Typical bottlenecks that C++ can address include:
   implementations of many important data structures, from ordered maps to 
   double-ended queues.
 
-The aim of this chapter is to discuss only those aspects of C++ and Rcpp that are absolutely necessary to help you eliminate bottlenecks in your code. We won't spend much time on advanced features like object oriented programming or templates because the focus is on writing small, self-contained functions, not big programs. A working knowledge of C++ is helpful, but not essential. Many good tutorials and references are freely available, including <http://www.learncpp.com/> and <http://www.cplusplus.com/>. For more advanced topics, the _Effective C++_ series by Scott Meyers is a popular choice. You may also enjoy Dirk Eddelbuettel's [_Seamless R and C++ integration with Rcpp_](http://www.springer.com/statistics/computational+statistics/book/978-1-4614-6867-7), which goes into much greater detail into all aspects of Rcpp.
+The aim of this chapter is to discuss only those aspects of C++ and Rcpp that are absolutely necessary to help you eliminate bottlenecks in your code. We won't spend much time on advanced features like object oriented programming or templates because the focus is on writing small, self-contained functions, not big programs. A working knowledge of C++ is helpful, but not essential. Many good tutorials and references are freely available, including <http://www.learncpp.com/> and <https://en.cppreference.com/w/cpp>. For more advanced topics, the _Effective C++_ series by Scott Meyers is a popular choice. You may also enjoy Dirk Eddelbuettel's [_Seamless R and C++ integration with Rcpp_](http://www.springer.com/statistics/computational+statistics/book/978-1-4614-6867-7), which goes into much greater detail into all aspects of Rcpp.
 
 ### Outline {-}
 
@@ -858,7 +858,7 @@ double sum4(NumericVector x) {
 
 ### Algorithms
 
-The `<algorithm>` header provides a large number of algorithms that work with iterators. A good reference is available at <http://www.cplusplus.com/reference/algorithm/>. For example, we could write a basic Rcpp version of `findInterval()` that takes two arguments a vector of values and a vector of breaks, and locates the bin that each x falls into. This shows off a few more advanced iterator features. Read the code below and see if you can figure out how it works. \indexc{findInterval()}
+The `<algorithm>` header provides a large number of algorithms that work with iterators. A good reference is available at <https://en.cppreference.com/w/cpp/algorithm>. For example, we could write a basic Rcpp version of `findInterval()` that takes two arguments a vector of values and a vector of breaks, and locates the bin that each x falls into. This shows off a few more advanced iterator features. Read the code below and see if you can figure out how it works. \indexc{findInterval()}
 
 ```{r, engine = "Rcpp"}
 #include <algorithm>


### PR DESCRIPTION
The C++ community seems to have converged to using cppreference as the "go to" place for online documentation and reference of the standard.  A key advantage is that cppreference is a community wiki -- an open platform as opposed to a closed one -- and generally have higher quality content. Another is that it doesn't have advertisements.

See the discussions here:

- https://stackoverflow.com/questions/6520052/whats-wrong-with-cplusplus-com
- https://meta.stackexchange.com/questions/194788/links-being-changed-to-cppreference-com

While the answers do not completely settle the issue, I find the arguments for preferring cppreference over cplusplus convincing.