### PR TITLE
Update Function-factories.Rmd to remove duplicate of word

### DIFF
--- a/Function-factories.Rmd
+++ b/Function-factories.Rmd
@@ -180,7 +180,7 @@ There are two things that make this possible:
   
 The usual assignment operator, `<-`, always creates a binding in the current environment. The __super assignment operator__, `<<-` rebinds an existing name found in a parent environment.
 
-The following example example shows how we can combine these ideas to create a function that records how many times it has been called:
+The following example shows how we can combine these ideas to create a function that records how many times it has been called:
 
 ```{r}
 new_counter <- function() {


### PR DESCRIPTION
I spotted a duplicate of word 'example' in the paragraph when reading the book online. I believe it is an typo and hopefully the proposal could help a little. I assign the copyright of this contribution to Hadley Wickham