### PR TITLE
alter the use of 'bootstrap'

### DIFF
--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -676,9 +676,10 @@ In this section we'll explore how tidy evaluation facilitates this division of r
 ### Quoting and unquoting
 \index{quoting!in practice}
 \index{unquoting!in practice}
-\index{bootstrapping}
+\index{
+strapping}
 
-Imagine we have written a function that bootstraps a function:
+Imagine we have written a function that draws random rows from a dataset, to help us bootstrap:
 
 ```{r}
 bootstrap <- function(df, n) {
@@ -687,7 +688,7 @@ bootstrap <- function(df, n) {
 }
 ```
 
-We want to create a new function that allows us to bootstrap and subset in a single step. Our naive approach doesn't work:
+We want to create a new function that allows us to subset and randomly draw rows in a single step. Our naive approach doesn't work:
 
 ```{r, error = TRUE}
 bootset <- function(df, cond, n = nrow(df)) {
@@ -1109,7 +1110,7 @@ There are two basic ways to overcome this challenge:
     ```
 
 1.  Another way to way to write `boot_lm()` would be to include the
-    bootstrapping expression (`data[sample(nrow(data), replace = TRUE), , drop = FALSE]`)
+    sampling expression (`data[sample(nrow(data), replace = TRUE), , drop = FALSE]`)
     in the data argument. Implement that approach. What are the advantages?
     What are the disadvantages?
 

--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -676,8 +676,7 @@ In this section we'll explore how tidy evaluation facilitates this division of r
 ### Quoting and unquoting
 \index{quoting!in practice}
 \index{unquoting!in practice}
-\index{
-strapping}
+\index{bootstrapping}
 
 Imagine we have written a function that draws random rows from a dataset, to help us bootstrap:
 


### PR DESCRIPTION
As a [bootstrapper in a previous life](https://scholar.google.com/scholar?hl=en&as_sdt=0%2C37&q=wh+beasley+bootstrap&btnG=), this chapter is offensive.

I'm kidding around, but I do think the term 'bootstrap' is a stretch, especially in the 'Quoting and unquoting' section.  In this first section, it doesn't meet most definitions of bootstrap because it lacks (a) a test-stat/function applied to the sampling frame and (b) a distribution of that function's values.  The `boot_lm()`s (in the 'The evaluation environment' section) now applies a function to a sampled draw, but still don't produce a distribution of the test stat.

To me, the existing `bootstrap()` is a specialized sampling function that doesn't immediately facilitate a statistical inference (about standard errors, etc).  Consider renaming `bootstrap()` to something like `sample_rows()`/`draw_rows()`/`pluck_rows()`.

I think this example is well-suited for your larger purpose of demonstrating expressions & environments and I learned from it (even though I've read [your nse vignette](http://adv-r.had.co.nz/Computing-on-the-language.html) 10+ times over the psat 2 years).  And I'm not advocating that you introduce a full sampling distribution in to the function.  Just advocating that a different term is used (and mention these sampling functions are the foundation for a bootstrap).  Your books are so popular and influential to so many fields, I don't want non-statisticians from getting an incomplete 1st impression of the technique.