### PR TITLE
update deprecated rlang functions for enviroment

### DIFF
--- a/Environments.Rmd
+++ b/Environments.Rmd
@@ -303,12 +303,12 @@ See `get()`, `assign()`, `exists()`, and `rm()`. These are designed interactivel
 
 There are two more exotic variants of `env_bind()`:
 
-*   `env_bind_exprs()` creates __delayed bindings__, which are evaluated the
+*   `env_bind_lazy()` creates __delayed bindings__, which are evaluated the
     first time they are accessed. Behind the scenes, delayed bindings create 
     promises, so behave in the same way as function arguments.
 
     ```{r, cache = TRUE}
-    env_bind_exprs(current_env(), b = {Sys.sleep(1); 1})
+    env_bind_lazy(current_env(), b = {Sys.sleep(1); 1})
     
     system.time(print(b))
     system.time(print(b))
@@ -318,11 +318,11 @@ There are two more exotic variants of `env_bind()`:
     allows R packages to provide datasets that behave like they are loaded in
     memory, even though they're only loaded from disk when needed.
 
-*   `env_bind_fns()` creates __active bindings__ which are re-computed every 
+*   `env_bind_active()` creates __active bindings__ which are re-computed every 
     time they're accessed:
 
     ```{r}
-    env_bind_fns(current_env(), z1 = function(val) runif(1))
+    env_bind_active(current_env(), z1 = function(val) runif(1))
     
     z1
     z1


### PR DESCRIPTION
```
Warning: `env_bind_exprs()` is soft-deprecated as of rlang 0.3.0.
Please use `env_bind_lazy()` instead.
This warning is displayed once per session.
```
```
Warning: `env_bind_fns()` is soft-deprecated as of rlang 0.3.0.
Please use `env_bind_active()` instead.
This warning is displayed once per session.
```