### PR TITLE
not modify Accumulator class in "14.2 Classes and methods"

### DIFF
--- a/R6.Rmd
+++ b/R6.Rmd
@@ -209,6 +209,7 @@ Accumulator <- R6Class("Accumulator")
 Accumulator$set("public", "sum", 0)
 Accumulator$set("public", "add", function(x = 1) {
   self$sum <- self$sum + x 
+  invisible(self)
 })
 ```
 


### PR DESCRIPTION
In https://adv-r.hadley.nz/r6.html#adding-methods-after-creation

```r
Accumulator <- R6Class("Accumulator")
Accumulator$set("public", "sum", 0)
Accumulator$set("public", "add", function(x = 1) {
  self$sum <- self$sum + x 
})
```

`$set` does not return `self`

So sub class can't chain methods

```r
AccumulatorChatty <- R6Class("AccumulatorChatty", 
  inherit = Accumulator,
  public = list(
    add = function(x = 1) {
      cat("Adding ", x, "\n", sep = "")
      super$add(x = x)
    }
  )
)

x2 <- AccumulatorChatty$new()
x2$add(10)$add(1)$sum
```

```
Adding 10
Error in x2$add(10)$add : $ operator is invalid for atomic vectors
```