### PR TITLE
Subsetting: Selecting multiple elements

### DIFF
--- a/Subsetting.Rmd
+++ b/Subsetting.Rmd
@@ -114,7 +114,7 @@ There are six things that you can use to subset a vector:
     is controlled by the __recycling rules__ where the shorter of the two is
     "recycled" to the length of the longer. This is convenient and easy to
     understand when one of `x` and `y` is length one, but I recommend avoiding
-    recycling for other lengths because the rules are consistently applied
+    recycling for other lengths because the rules are inconsistently applied
     throughout base R.
   
     ```{r}

--- a/Subsetting.Rmd
+++ b/Subsetting.Rmd
@@ -59,19 +59,19 @@ Take this short quiz to determine if you need to read this chapter. If the answe
 ## Selecting multiple elements {#subset-multiple}
 \indexc{[}
 
-Use `[` to select any number elements from a vector. I'll start by applying it to 1D atomic vectors, and then show how it generalises to more complex objects and more dimensions.
+Use `[` to select any number of elements from a vector. To illustrate, I'll apply `[` to 1D atomic vectors, and then show how this generalises to more complex objects and more dimensions.
 
 ### Atomic vectors
 \index{subsetting!atomic vectors} 
 \index{atomic vectors!subsetting} 
 
-Let's explore the different types of subsetting with a simple vector, `x`. 
+Let's explore the different types of subsetting with a simple vector, `x`.  
 
 ```{r}
 x <- c(2.1, 4.2, 3.3, 5.4)
 ```
 
-Note that the number after the decimal point gives the original position in the vector.
+Note that the number after the decimal point represents the original position in the vector.
 
 There are six things that you can use to subset a vector: 
 
@@ -81,20 +81,20 @@ There are six things that you can use to subset a vector:
     x[c(3, 1)]
     x[order(x)]
 
-    # Duplicated indices yield duplicated values
+    # Duplicate indices will duplicate values
     x[c(1, 1)]
 
     # Real numbers are silently truncated to integers
     x[c(2.1, 2.9)]
     ```
 
-*   __Negative integers__ omit elements at the specified positions:
+*   __Negative integers__ exclude elements at the specified positions:
 
     ```{r}
     x[-c(3, 1)]
     ```
 
-    You can't mix positive and negative integers in a single subset:
+    Note that you can't mix positive and negative integers in a single subset:
 
     ```{r, error = TRUE}
     x[c(-1, 2)]
@@ -102,8 +102,8 @@ There are six things that you can use to subset a vector:
 
 *   __Logical vectors__ select elements where the corresponding logical 
     value is `TRUE`. This is probably the most useful type of subsetting
-    because you can write an expression that creates the logical vector:
-
+    because you can write an expression that uses a logical vector:
+    
     ```{r}
     x[c(TRUE, TRUE, FALSE, FALSE)]
     x[x > 3]
@@ -111,8 +111,8 @@ There are six things that you can use to subset a vector:
 
     \index{recycling}
     In `x[y]`, what happens if `x` and `y` are different lengths? The behaviour 
-    is controlled by the __recycling rules__, and the shorter of the two will
-    be "recycled" to the length of the longer. This is convenient and easy to
+    is controlled by the __recycling rules__ where the shorter of the two is
+    "recycled" to the length of the longer. This is convenient and easy to
     understand when one of `x` and `y` is length one, but I recommend avoiding
     recycling for other lengths because the rules are consistently applied
     throughout base R.
@@ -123,14 +123,14 @@ There are six things that you can use to subset a vector:
     x[c(TRUE, FALSE, TRUE, FALSE)]
     ```
 
-    A missing value in the index always yields a missing value in the output:
+    Note that a missing value in the index always yields a missing value in the output:
 
     ```{r}
     x[c(TRUE, TRUE, NA, FALSE)]
     ```
 
-*   __Nothing__ returns the original vector. This is not useful for 1d vectors,
-    but as you'll see shortly, is very useful for matrices, data frames, and arrays. 
+*   __Nothing__ returns the original vector. This is not useful for 1D vectors,
+    but, as you'll see shortly, is very useful for matrices, data frames, and arrays. 
     It can also be useful in conjunction with assignment.
 
     ```{r}
@@ -159,7 +159,7 @@ There are six things that you can use to subset a vector:
     z[c("a", "d")]
     ```
 
-NB: factors are not treated specially when subsetting. This means that subsetting will use the underlying integer vector, not the character levels. This is typically unexpected, so you should avoid subsetting with factors:
+NB: Factors are not treated specially when subsetting. This means that subsetting will use the underlying integer vector, not the character levels. This is typically unexpected, so you should avoid subsetting with factors:
 
 ```{r}
 y[factor("b")]


### PR DESCRIPTION
recycling: "This is convenient and easy to  understand when one of `x` and `y` is length one, but I recommend avoiding recycling for other lengths because the rules are consistently applied throughout base R."

"inconsistently applied" or "too consistently" (recycling based on multiples of length might not be what you want)