### PR TITLE
unifies the order of the atomic vectors types

### DIFF
--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -71,7 +71,7 @@ Take this short quiz to determine if you need to read this chapter. If the answe
 \index{numeric vectors} 
 \index{character vectors} 
 
-There are four primary types of atomic vectors: logical, integer, double, and character (which contains strings). Collectively integer and double vectors are known as numeric vectors[^numeric]. There are two rare types: complex and raw. I won't discuss them further because complex numbers are rarely needed in statistics, and raw vectors are a special type that's only needed when handling binary data. 
+There are four primary types of atomic vectors: double, integer, logical, and character (which contains strings). Collectively double and integer vectors are known as numeric vectors[^numeric]. There are two rare types: complex and raw. I won't discuss them further because complex numbers are rarely needed in statistics, and raw vectors are a special type that's only needed when handling binary data. 
 
 ```{r, echo = FALSE, out.width = NULL}
 knitr::include_graphics("diagrams/vectors/summary-tree-atomic.png")
@@ -89,9 +89,6 @@ knitr::include_graphics("diagrams/vectors/summary-tree-atomic.png")
 
 Each of the four primary types has a special syntax to create an individual value, AKA a __scalar__[^scalar]:
 
-* Strings are surrounded by `"` (`"hi"`) or `'` (`'bye'`). Special characters
-  are escaped with `\`; see `?Quotes` for full details.
-
 * Doubles can be specified in decimal (`0.1234`), scientific (`1.23e4`), or 
   hexadecimal (`0xcafe`) form. There are three special values unique to
   doubles: `Inf`, `-Inf`, and `NaN` (not a number). These are special values
@@ -101,6 +98,9 @@ Each of the four primary types has a special syntax to create an individual valu
   `L`[^L-suffix] (`1234L`, `1e4L`, or `0xcafeL`), and can not include decimals. 
 
 * Logicals can be spelt out (`TRUE` or `FALSE`), or abbreviated (`T` or `F`).
+
+* Strings are surrounded by `"` (`"hi"`) or `'` (`'bye'`). Special characters
+  are escaped with `\`; see `?Quotes` for full details.
 
 [^L-suffix]: `L` is not intuitive, and you might wonder where it comes from. At the time `L` was added to R, R's integer type was equivalent to a long integer in C, and C code could use a suffix of `l` or `L` to force a number to be a long integer. It was decided that `l` was too visually similar to `i` (used for complex numbers in R), leaving `L`.
 


### PR DESCRIPTION
Most of the example in this chapter are using the following order: double, integer, logical, character. However, there are two places when the order is different. This PR unifies how the atomic vectors types are explained.