### PR TITLE
Explicit anchors for part introductions

### DIFF
--- a/Meta.Rmd
+++ b/Meta.Rmd
@@ -1,6 +1,6 @@
 # (PART) Metaprogramming {-}
 
-# Introduction {.unnumbered}
+# Introduction {#metaprogramming .unnumbered}
 
 ```{r, include = FALSE}
 source("common.R")

--- a/Techniques.Rmd
+++ b/Techniques.Rmd
@@ -1,6 +1,6 @@
 # (PART) Techniques {-}
 
-# Introduction {.unnumbered}
+# Introduction {#techniques .unnumbered}
 
 The final four chapters cover two general programming techniques: finding and fixing bugs, and finding and fixing performance issues.
 


### PR DESCRIPTION
Makes the URL look like

GOOD, unnumbered:
https://adv-r.hadley.nz/techniques.html

instead of

YUCK:
https://adv-r.hadley.nz/introduction-22.html