### PR TITLE
Names and values edited

### DIFF
--- a/Names-values.Rmd
+++ b/Names-values.Rmd
@@ -289,13 +289,13 @@ knitr::include_graphics("diagrams/name-value/binding-f2.png")
 \indexc{ref()}
 \index{lists}
 
-It's not just names (i.e. variables) that point to values; elements of lists do too. Take this list, which is superficially very similar to the numeric vector above:
+Names (i.e. variables) point to values; elements of lists do too. Consider this list, which is superficially very similar to the numeric vector above:
 
 ```{r list1}
 l1 <- list(1, 2, 3)
 ```
 
-This list is more complex because instead of storing the values itself, it instead stores references to them:
+This list is more complex because instead of storing the values itself, it stores references to them:
 
 ```{r, echo = FALSE, out.width = NULL}
 knitr::include_graphics("diagrams/name-value/list.png")
@@ -465,7 +465,7 @@ References also make it challenging to think about the size of individual object
 obj_size(x, y)
 ```
 
-Finally, R 3.5.0 and later have a feature that might lead to surprises: ALTREP, short for __alternative representation__. This allows R to represent certain types of vectors very compactly. The place you are most like to see this is with `:` because instead of storing every single number in the sequence, R just stores the first and last number. This means that every sequence, no matter how large, is the same size:
+Finally, R 3.5.0 and later versions have a feature that might lead to surprises: ALTREP, short for __alternative representation__. This allows R to represent certain types of vectors very compactly. The place you are most like to see this is with `:` because instead of storing every single number in the sequence, R just stores the first and last number. This means that every sequence, no matter how large, is the same size:
 
 ```{r}
 obj_size(1:3)
@@ -562,7 +562,7 @@ Together, these two complications make it hard to predict whether or not a copy 
 
 \index{loops!performance}
 \index{for loops|see {loops}}
-Let's explore the subtleties with a case study using for loops. For loops have a reputation for being slow in R, but often that slowness is caused by every iteration of the loop creating a copy. Consider the following code. It subtracts the median from each column of a large data frame: 
+Let's explore the subtleties with a case study using `for` loops. `For` loops have a reputation for being slow in R, but often that slowness is caused by every iteration of the loop creating a copy. Consider the following code. It subtracts the median from each column of a large data frame: 
 
 ```{r, cache = TRUE}
 x <- data.frame(matrix(runif(5 * 1e4), ncol = 5))
@@ -605,7 +605,7 @@ In fact, each iteration copies the data frame not once, not twice, but three tim
 
 [^shallow-copy]: These copies are shallow: they only copy the reference to each individual column, not the contents of the columns. This means the performance isn't terrible, but it's obviously not as good as it could be.
 
-We can reduce the number of copies by using a list instead of a data frame. Modifying a list uses internal C code, so the refs are not incremented and only a single copy is made:
+We can reduce the number of copies by using a list instead of a data frame. Modifying a list uses internal C code, so the references are not incremented and only a single copy is made:
 
 ```{r, eval = FALSE}
 y <- as.list(x)
@@ -738,7 +738,7 @@ This number won't agree with the amount of memory reported by your operating sys
 1. R counts the memory occupied by objects but there may be empty gaps due to 
    deleted objects. This problem is known as memory fragmentation.
 
-## Answers {#names-values-answers}
+## Quiz Answers {#names-values-answers}
 
 1.  You must quote non-syntactic names with backticks: `` ` ``: for example,
     the variables `1`, `2`, and `3`.

--- a/Names-values.Rmd
+++ b/Names-values.Rmd
@@ -289,7 +289,7 @@ knitr::include_graphics("diagrams/name-value/binding-f2.png")
 \indexc{ref()}
 \index{lists}
 
-Names (i.e. variables) point to values; elements of lists do too. Consider this list, which is superficially very similar to the numeric vector above:
+It's not just names (i.e. variables) that point to values; elements of lists do too. Consider this list, which is superficially very similar to the numeric vector above:
 
 ```{r list1}
 l1 <- list(1, 2, 3)
@@ -562,7 +562,7 @@ Together, these two complications make it hard to predict whether or not a copy 
 
 \index{loops!performance}
 \index{for loops|see {loops}}
-Let's explore the subtleties with a case study using `for` loops. `For` loops have a reputation for being slow in R, but often that slowness is caused by every iteration of the loop creating a copy. Consider the following code. It subtracts the median from each column of a large data frame: 
+Let's explore the subtleties with a case study using for loops. For loops have a reputation for being slow in R, but often that slowness is caused by every iteration of the loop creating a copy. Consider the following code. It subtracts the median from each column of a large data frame: 
 
 ```{r, cache = TRUE}
 x <- data.frame(matrix(runif(5 * 1e4), ncol = 5))


### PR DESCRIPTION
Unimportant comment: At the beginning of section **2.3.3 List** the editor suggests "Names (i.e. variables) point to values;...". I made the change but I think that the original version sounds better.