### PR TITLE
Vectors

### DIFF
--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -236,7 +236,7 @@ as.integer(c("1", "1.5", "a"))
 ## Attributes {#attributes}
 \index{attributes}
 
-You might have noticed that the set of atomic vectors does not include a number of important data structures like matrices, arrays, factors or date-times. These types are built on top of atomic vectors by adding attributes. In this section, you'll learn the basics of attributes, and how the dim attribute makes matrices and arrays. In the next section you'll learn how the class attribute is used to create S3 vectors, including factors, dates, and date-times.
+You might have noticed that the set of atomic vectors does not include a number of important data structures like matrices, arrays, factors, or date-times. These types are built on top of atomic vectors by adding attributes. In this section, you'll learn the basics of attributes, and how the dim attribute makes matrices and arrays. In the next section you'll learn how the class attribute is used to create S3 vectors, including factors, dates, and date-times.
 
 ### Getting and setting
 \indexc{attr()}

--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -236,7 +236,7 @@ as.integer(c("1", "1.5", "a"))
 ## Attributes {#attributes}
 \index{attributes}
 
-You might have noticed that the set of atomic vectors does not include a number of important data structures like matrices and arrays, factors, and dates and times. These types are built on top of atomic vectors by adding attributes. In this section, you'll learn the basics of attributes, and how the dim attribute makes matrices and arrays. In the next section you'll learn how the class attribute is used to create S3 vectors, including factors, dates, and date-times.
+You might have noticed that the set of atomic vectors does not include a number of important data structures like matrices, arrays, factors or date-times. These types are built on top of atomic vectors by adding attributes. In this section, you'll learn the basics of attributes, and how the dim attribute makes matrices and arrays. In the next section you'll learn how the class attribute is used to create S3 vectors, including factors, dates, and date-times.
 
 ### Getting and setting
 \indexc{attr()}

--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -19,7 +19,7 @@ knitr::include_graphics("diagrams/vectors/summary-tree.png")
 
 [^generic-vectors]: A few places in R's documentation call lists generic vectors to emphasise their difference from atomic vectors.
 
-Every vector can also have __attributes__, which you can think of as a named list of arbitrary metadata. Two attributes are particularly important. The **dim**ension attribute turns vectors into matrices and arrays and the __class__ attribute powers the S3 object system. While you'll learn how to use S3 in Chapter \@ref(s3)), here you'll learn about some of the most important S3 vectors: factors, date/times, data frames, and tibbles. And while 2D structures like matrices and data frames are not necessarily what come to mind when you think of vectors, you'll also learn why R considers them to be vectors.
+Every vector can also have __attributes__, which you can think of as a named list of arbitrary metadata. Two attributes are particularly important. The __dimension__ attribute turns vectors into matrices and arrays and the __class__ attribute powers the S3 object system. While you'll learn how to use S3 in Chapter \@ref(s3), here you'll learn about some of the most important S3 vectors: factors, date and times, data frames, and tibbles. And while 2D structures like matrices and data frames are not necessarily what come to mind when you think of vectors, you'll also learn why R considers them to be vectors.
 
 ### Quiz {-}
 
@@ -185,7 +185,7 @@ NB: Technically there are four missing values, one for each of the atomic types:
 \indexc{is.atomic()}
 \indexc{is.numeric()}
 
-Generally, you can __test__ if a vector is of a given type with an `is.*()` function, but they need to be used with care. `is.character()`, `is.double()`, `is.integer()`, and `is.logical()` do what you might expect: they test if a vector is a character, double, integer, or logical. Avoid `is.vector()`, `is.atomic()`, and `is.numeric()`: they don't test if you have a vector, atomic vector, or numeric vector; you'll need to carefully read the docs to figure out what they actually do.
+Generally, you can __test__ if a vector is of a given type with an `is.*()` function, but these functions need to be used with care. `is.character()`, `is.double()`, `is.integer()`, and `is.logical()` do what you might expect: they test if a vector is a character, double, integer, or logical. Avoid `is.vector()`, `is.atomic()`, and `is.numeric()`: they don't test if you have a vector, atomic vector, or numeric vector; you'll need to carefully read the documentation to figure out what they actually do.
 
 For atomic vectors, type is a property of the entire vector: all elements must be the same type. When you attempt to combine different types they will be __coerced__ in a fixed order: character → double → integer → logical. For example, combining a character and an integer yields a character:
 
@@ -215,7 +215,7 @@ as.integer(c("1", "1.5", "a"))
 ### Exercises
 
 1. How do you create raw and complex scalars? (See `?raw` and 
-   `?complex`)
+   `?complex`.)
 
 1. Test your knowledge of the vector coercion rules by predicting the output of
    the following uses of `c()`:
@@ -236,7 +236,7 @@ as.integer(c("1", "1.5", "a"))
 ## Attributes {#attributes}
 \index{attributes}
 
-You might have noticed that the set of atomic vectors does not include a number of important data structures like matrices and arrays, factors and date/times. These types are built on top of atomic vectors by adding attributes. In this section, you'll learn the basics of attributes, and how the dim attribute makes matrices and arrays. In the next section you'll learn how the class attribute is used to create S3 vectors, including factors, dates, and date-times.
+You might have noticed that the set of atomic vectors does not include a number of important data structures like matrices and arrays, factors and dates and times. These types are built on top of atomic vectors by adding attributes. In this section, you'll learn the basics of attributes, and how the dim attribute makes matrices and arrays. In the next section you'll learn how the class attribute is used to create S3 vectors, including factors, dates, and date-times.
 
 ### Getting and setting
 \indexc{attr()}
@@ -323,7 +323,7 @@ To be useful with character subsetting (e.g. Section \@ref(lookup-tables)) names
 \index{matrices|see {arrays}}
 \index{attributes!dimensions}
 
-Adding a `dim` attribute to a vector allows it to behave like a 2-dimensional __matrix__ or a multi-dimensional __array__. Matrices and arrays are primarily mathematical/statistical tools, not programming tools, so they'll be used infrequently and only covered briefly in this book. Their most important feature is multidimensional subsetting, which is covered in Section \@ref(matrix-subsetting).
+Adding a `dim` attribute to a vector allows it to behave like a 2-dimensional __matrix__ or a multi-dimensional __array__. Matrices and arrays are primarily mathematical and statistical tools, not programming tools, so they'll be used infrequently and only covered briefly in this book. Their most important feature is multidimensional subsetting, which is covered in Section \@ref(matrix-subsetting).
 
 You can create matrices and arrays with `matrix()` and `array()`, or by using the assignment form of `dim()`:
 
@@ -366,7 +366,7 @@ str(array(1:3, 3))         # "array" vector
 1.  How is `setNames()` implemented? How is `unname()` implemented?
     Read the source code.
 
-1.  What does `dim()` return when applied to a 1D vector?
+1.  What does `dim()` return when applied to a 1-dimensional vector?
     When might you use `NROW()` or `NCOL()`?
 
 1.  How would you describe the following three objects? What makes them
@@ -437,7 +437,7 @@ table(sex_char)
 table(sex_factor)
 ```
 
-A minor variation on factors are __ordered__ factors. In general, they behave like regular factors, but the order of the levels is meaningful ("low", "medium", "high") (a property that is automatically leveraged by some modelling and visualisation functions).
+__Ordered__ factors are a minor variation of factors. In general, they behave like regular factors, but the order of the levels is meaningful (low, medium, high) (a property that is automatically leveraged by some modelling and visualisation functions).
 
 ```{r}
 grade <- ordered(c("b", "b", "a", "c"), levels = c("c", "b", "a"))
@@ -502,7 +502,7 @@ structure(now_ct, tzone = "Europe/Paris")
 \index{durations|see {difftime}}
 \indexc{difftime}
 
-Durations, the amount of time between two dates or date times, are stored in difftimes. Difftimes are built on top of doubles, and have a units attribute that determines how the integer should be interpreted:
+Durations, the amounts of time between two dates or date times, are stored in difftimes. Difftimes are built on top of doubles, and have a units attribute that determines how the integer should be interpreted:
 
 ```{r}
 one_week_1 <- as.difftime(1, units = "weeks")
@@ -765,7 +765,7 @@ knitr::include_graphics("diagrams/vectors/data-frame-2.png")
 ### Row names {#rownames}
 \indexc{row.names}
 
-Data frames allow you to label each row with a "name", a character vector containing only unique values:
+Data frames allow you to label each row with a name, a character vector containing only unique values:
 
 ```{r}
 df3 <- data.frame(
@@ -925,7 +925,7 @@ tibble(
 ### Matrix and data frame columns
 \index{data frames!matrix-columns}
 
-As long as the number of rows matches the data frame, it's also possible to have a matrix or array as a column of a data frame. (This requires a slight extension to our definition of a data frame: it's not the `length()` of each column that must be equal, but the `NROW()`.) Like with list-columns, you must either add it after creation, or wrap it in `I()`.
+As long as the number of rows matches the data frame, it's also possible to have a matrix or array as a column of a data frame. (This requires a slight extension to our definition of a data frame: it's not the `length()` of each column that must be equal, but the `NROW()`.) As for list-columns, you must either add it after creation, or wrap it in `I()`.
 
 ```{r}
 dfm <- data.frame(
@@ -996,7 +996,7 @@ There are two common uses of `NULL`:
 
 If you're familiar with SQL, you'll know about relational `NULL` and might expect it to be the same as R's. However, the database `NULL` is actually equivalent to R's `NA`.
 
-## Answers {#data-structure-answers}
+## Quiz Answers {#data-structure-answers}
 
 1.  The four common types of atomic vector are logical, integer, double 
     and character. The two rarer types are complex and raw.
@@ -1011,7 +1011,7 @@ If you're familiar with SQL, you'll know about relational `NULL` and might expec
     a matrix must be the same type; in a data frame, different columns can have 
     different types.
     
-1.  You can make a "list-array" by assigning dimensions to a list. You can
+1.  You can make a list-array by assigning dimensions to a list. You can
     make a matrix a column of a data frame with `df$x <- matrix()`, or by
     using `I()` when creating a new data frame `data.frame(x = I(matrix()))`.
 

--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -236,7 +236,7 @@ as.integer(c("1", "1.5", "a"))
 ## Attributes {#attributes}
 \index{attributes}
 
-You might have noticed that the set of atomic vectors does not include a number of important data structures like matrices and arrays, factors and dates and times. These types are built on top of atomic vectors by adding attributes. In this section, you'll learn the basics of attributes, and how the dim attribute makes matrices and arrays. In the next section you'll learn how the class attribute is used to create S3 vectors, including factors, dates, and date-times.
+You might have noticed that the set of atomic vectors does not include a number of important data structures like matrices and arrays, factors, and dates and times. These types are built on top of atomic vectors by adding attributes. In this section, you'll learn the basics of attributes, and how the dim attribute makes matrices and arrays. In the next section you'll learn how the class attribute is used to create S3 vectors, including factors, dates, and date-times.
 
 ### Getting and setting
 \indexc{attr()}
@@ -502,7 +502,7 @@ structure(now_ct, tzone = "Europe/Paris")
 \index{durations|see {difftime}}
 \indexc{difftime}
 
-Durations, the amounts of time between two dates or date times, are stored in difftimes. Difftimes are built on top of doubles, and have a units attribute that determines how the integer should be interpreted:
+Durations, which represent the amount of time between pairs of dates or date-times, are stored in difftimes. Difftimes are built on top of doubles, and have a units attribute that determines how the integer should be interpreted:
 
 ```{r}
 one_week_1 <- as.difftime(1, units = "weeks")


### PR DESCRIPTION
* In p.45 there's a note to "delete the duplicate =". I left it as is. 

* p. 52 The correction reads "__Ordered__ factors are minor variations of factors".   
I think that "__Ordered__ factors are a minor variation of factors" works better. The former implies that each ordered factor is a variation of factors while the later implies that ordered factors __as a class__ are a variation of
  factors.

* p. 65 Asks for monotype font in "dplyr". Throughout the rest of the book package names are not monotyped (I seem to remember it's on the tidyverse style guide) and I didn't see notes there. I left it as is. 