### PR TITLE
subsetting edited

### DIFF
--- a/Subsetting.Rmd
+++ b/Subsetting.Rmd
@@ -46,7 +46,7 @@ Take this short quiz to determine if you need to read this chapter. If the answe
   
 * Section \@ref(subset-single) expands your knowledge of subsetting 
   operators to include `[[` and `$` and focuses on the important 
-  principles of simplifying vs. preserving.
+  principles of simplifying versus preserving.
   
 * In Section \@ref(subassignment) you'll learn the art of 
   subassignment, which combines subsetting and assignment to modify 
@@ -112,7 +112,7 @@ There are six things that you can use to subset a vector:
     \index{recycling}
     In `x[y]`, what happens if `x` and `y` are different lengths? The behaviour 
     is controlled by the __recycling rules__ where the shorter of the two is
-    "recycled" to the length of the longer. This is convenient and easy to
+    recycled to the length of the longer. This is convenient and easy to
     understand when one of `x` and `y` is length one, but I recommend avoiding
     recycling for other lengths because the rules are inconsistently applied
     throughout base R.
@@ -169,7 +169,7 @@ y[factor("b")]
 \index{lists!subsetting} 
 \index{subsetting!lists}
 
-Subsetting a list works in the same way as subsetting an atomic vector. Using `[` always return a list; `[[` and `$`, as described in Section \@ref(subset-single), let you pull out elements of a list.  
+Subsetting a list works in the same way as subsetting an atomic vector. Using `[` always returns a list; `[[` and `$`, as described in Section \@ref(subset-single), lets you pull out elements of a list.  
 
 ### Matrices and arrays {#matrix-subsetting}
 \index{subsetting!arrays} 
@@ -423,13 +423,13 @@ x$a
 
 (For data frames, you can also avoid this problem by using tibbles, which never do partial matching.)
 
-### Missing/out of bounds indices {#subsetting-oob}
+### Missing and out-of-bounds indices {#subsetting-oob}
 \index{subsetting!with NA \& NULL} 
 \index{subsetting!out of bounds}
 \indexc{pluck()}
 \indexc{chuck()}
 
-It's useful to understand what happens with `[[` when you use an "invalid" index. The following table summarise what happens when you subset a logical vector, list, and `NULL` with a zero-length object (like `NULL` or `logical()`), out-of-bounds values (OOB), or a missing value (e.g. `NA_integer_`) with `[[`. Each cell shows the result of subsetting the data structure named in the row by the type of index described in the column. I've only shown the results for logical vectors, but other atomic vectors behave similarly, returning elements of the same type.
+It's useful to understand what happens with `[[` when you use an "invalid" index. The following table summarise what happens when you subset a logical vector, list, and `NULL` with a zero-length object (like `NULL` or `logical()`), out-of-bounds values (OOB), or a missing value (e.g. `NA_integer_`) with `[[`. Each cell shows the result of subsetting the data structure named in the row by the type of index described in the column. I've only shown the results for logical vectors, but other atomic vectors behave similarly, returning elements of the same type (NB: int = integer; chr = character).
 
 | `row[[col]]` | Zero-length | OOB (int)  | OOB (chr) | Missing  |
 |--------------|-------------|------------|-----------|----------|
@@ -454,7 +454,7 @@ NULL[[NA_real_]]
 NULL[[NULL]]
 ```
 
-If the vector being indexed is named, then the names of OOB, missing, or `NULL` components will be `"<NA>"`.
+If the vector being indexed is named, then the names of OOB, missing, or `NULL` components will be `<NA>`.
 
 The inconsistencies in the table above led to the development of `purrr::pluck()` and `purrr::chuck()`. When the element is missing, `pluck()` always returns `NULL` (or the value of the `.default` argument) and `chuck()` always throws an error. The behaviour of `pluck()` makes it well suited for indexing into deeply nested data structures where the component you want may not exist (as is common when working with JSON data from web APIs). `pluck()` also allows you to mix integer and character indices, and provides an alternative default value if an item does not exist:
 
@@ -574,7 +574,7 @@ info[id, ]
 
 If you're matching on multiple columns, you'll need to first collapse them into a single column (with e.g. `interaction()`). Typically, however, you're better off switching to a function designed specifically for joining multiple tables like `merge()`, or `dplyr::left_join()`.
 
-### Random samples/bootstraps (integer subsetting)
+### Random samples and bootstraps (integer subsetting)
 \index{sampling} 
 \index{bootstrapping}
 
@@ -622,7 +622,7 @@ df2[order(df2$x), ]
 df2[, order(names(df2))]
 ```
 
-You can sort vectors directly with `sort()`, or similarly `dplyr::arrange(), to sort a data frame.
+You can sort vectors directly with `sort()`, or similarly `dplyr::arrange()`, to sort a data frame.
 
 ### Expanding aggregated counts (integer subsetting)
 
@@ -635,7 +635,8 @@ rep(1:nrow(df), df$n)
 df[rep(1:nrow(df), df$n), ]
 ```
 
-### Removing columns from data frames (character subsetting)
+
+### Removing columns from data frames (character \mbox{subsetting})
 
 There are two ways to remove columns from a data frame. You can set individual columns to `NULL`: 
 
@@ -676,19 +677,19 @@ Remember to use the vector boolean operators `&` and `|`, not the short-circuiti
 
 For example, `!(X & !(Y | Z))` simplifies to `!X | !!(Y|Z)`, and then to `!X | Y | Z`.
 
-### Boolean algebra vs. sets (logical & integer subsetting)
+### Boolean algebra versus sets (logical and integer \mbox{subsetting})
 \index{Boolean algebra} 
 \index{set algebra}
 \indexc{which()}
 
-It's useful to be aware of the natural equivalence between set operations (integer subsetting) and boolean algebra (logical subsetting). Using set operations is more effective when: 
+It's useful to be aware of the natural equivalence between set operations (integer subsetting) and Boolean algebra (logical subsetting). Using set operations is more effective when: 
 
 * You want to find the first (or last) `TRUE`.
 
 * You have very few `TRUE`s and very many `FALSE`s; a set representation 
   may be faster and require less storage.
 
-`which()` allows you to convert a boolean representation to an integer representation. There's no reverse operation in base R but we can easily create one: 
+`which()` allows you to convert a Boolean representation to an integer representation. There's no reverse operation in base R but we can easily create one: 
 
 ```{r}
 x <- sample(10) < 4
@@ -702,7 +703,7 @@ unwhich <- function(x, n) {
 unwhich(which(x), 10)
 ```
 
-Let's create two logical vectors and their integer equivalents, and then explore the relationship between boolean and set operations.
+Let's create two logical vectors and their integer equivalents, and then explore the relationship between Boolean and set operations.
 
 ```{r}
 (x1 <- 1:10 %% 2 == 0)
@@ -752,7 +753,7 @@ In general, avoid switching from logical to integer subsetting unless you want, 
     
 1.  How could you put the columns in a data frame in alphabetical order?
 
-## Answers {#subsetting-answers}
+## Quiz Answers {#subsetting-answers}
 
 1.  Positive integers select elements at specific positions, negative integers
     drop elements; logical vectors keep elements at positions corresponding to


### PR DESCRIPTION
I used \mbox{} to avoid hyphenated words in titles.