### PR TITLE
Control Flow

### DIFF
--- a/Control-flow.Rmd
+++ b/Control-flow.Rmd
@@ -8,7 +8,7 @@ source("common.R")
 
 There are two primary tools of control flow: choices and loops. Choices, like `if` statements and `switch()` calls, allow you to run different code depending on the input. Loops, like `for` and `while`, allow you to repeatedly run code, typically with changing options. I'd expect that you're already familiar with the basics of these functions so I'll briefly cover some technical details and then introduce some useful, but lesser known, features.
 
-The condition system (messages, warnings, and errors), which you'll learn about them in Chapter \@ref(conditions), also provides "non-local" control flow. 
+The condition system (messages, warnings, and errors), which you'll learn about in Chapter \@ref(conditions), also provides non-local control flow. 
 
 ### Quiz {-}
 
@@ -245,7 +245,7 @@ for (i in 1:3) {
 
 (When iterating over a vector of indices, it's conventional to use very short variable names like `i`, `j`, or `k`.)
 
-N.B.: `for` assigns the `item` to the current environment, overwritting any existing variable with the same name:
+N.B.: `for` assigns the `item` to the current environment, overwriting any existing variable with the same name:
 
 ```{r}
 i <- 100
@@ -378,7 +378,7 @@ Generally speaking you shouldn't need to use for loops for data analysis tasks, 
     }
     ```
 
-## Answers {#control-flow-answers}
+## Quiz Answers {#control-flow-answers}
 
 * `if` works with scalars; `ifelse()` works with vectors.
 


### PR DESCRIPTION
* p.97 Asks for "for loop" to be in monospace. I left it as is in light of the previous correction (https://github.com/hadley/adv-r/pull/1482/files/c02c21c9a27734e3f2a760a294ac30ebd70645b0#diff-8e73443dc8245dbb3244c3b6fa3b8113)

