### PR TITLE
Base Types

### DIFF
--- a/base-types.Rmd
+++ b/base-types.Rmd
@@ -8,7 +8,7 @@
 source("common.R")
 ```
 
-To talk about objects and OOP in R we first need to clear up a fundamental confusion about two uses of the word "object". So far in this book, we've used the word in the general sense captured by John Chambers' pithy quote: "Everything that exists in R is an object". However, while everything _is_ an object, not everything is "object-oriented". This confusion arises because the base objects come from S, and were developed before anyone thought that S might need an OOP system. The tools and nomenclature evolved organically over many years without a single guiding principle.
+To talk about objects and OOP in R we first need to clear up a fundamental confusion about two uses of the word "object". So far in this book, we've used the word in the general sense captured by John Chambers' pithy quote: "Everything that exists in R is an object". However, while everything _is_ an object, not everything is object-oriented. This confusion arises because the base objects come from S, and were developed before anyone thought that S might need an OOP system. The tools and nomenclature evolved organically over many years without a single guiding principle.
 
 Most of the time, the distinction between objects and object-oriented objects is not important. But here we need to get into the nitty gritty details so we'll use the terms __base objects__ and __OO objects__ to distinguish them.
 
@@ -20,10 +20,9 @@ knitr::include_graphics("diagrams/oo-venn.png")
 
 * Section \@ref(base-vs-oo) shows you how to identify base and OO objects.
 
-* Section \@ref(base-types-2) gives a complete set of the base types that all
-  objects are built up from.
-  
-## Base vs OO objects {#base-vs-oo}
+* Section \@ref(base-types-2) gives a complete set of the base types used to build all objects.
+
+## Base versus OO objects {#base-vs-oo}
 \indexc{is.object()}
 \indexc{otype()}
 \index{attributes!class}
@@ -140,13 +139,13 @@ You may have heard of `mode()` and `storage.mode()`. Do not use these functions:
 \index{numeric vectors}
 \index{vectors!numeric|see {numeric vectors}}
 
-Be careful when talking about the "numeric" type, because R uses "numeric" to mean three slightly different things:
+Be careful when talking about the numeric type, because R uses "numeric" to mean three slightly different things:
 
-1.  In some places numeric is used as an alias for the "double" type. For 
+1.  In some places numeric is used as an alias for the double type. For 
     example `as.numeric()` is identical to `as.double()`, and `numeric()` is
     identical to `double()`.
     
-    (R also occasionally uses "real" instead of double; `NA_real_` is the one 
+    (R also occasionally uses real instead of double; `NA_real_` is the one 
     place that you're likely to encounter this in practice.)
     
 1.  In the S3 and S4 systems, numeric is used as a shorthand for either 


### PR DESCRIPTION
* p.291 Editor asks to remove hyphen in "object-oriented". The words appear throughout the book with and without hyphens. I don't know if there's a meaningful disctinction between the two. Should we choose a nomenclature and change it throughout?