### PR TITLE
S3

### DIFF
--- a/S3.Rmd
+++ b/S3.Rmd
@@ -233,7 +233,7 @@ The constructor should follow three principles:
 
 * Check the type of the base object and the types of each attribute.
 
-I'll illustrate these ideas by creating constructors for base classes[^base-constructors] that you're already familiar with. To start, lets make a constructor for the simplest S3 class: `Date`. A `Date` is just a double with "Date" as its `class` attribute, and no additional attributes. This makes for a very simple constructor:
+I'll illustrate these ideas by creating constructors for base classes[^base-constructors] that you're already familiar with. To start, lets make a constructor for the simplest S3 class: `Date`. A `Date` is just a double with a single attribute: its `class` is "Date". This makes for a very simple constructor:
 
 [^base-constructors]: Recent versions of R have `.Date()`, `.difftime()`, `.POSIXct()`, and `.POSIXlt()` constructors but they are internal, not well documented, and do not follow the principles that I recommend.
 
@@ -292,7 +292,7 @@ new_factor(1:5, "a")
 new_factor(0:1, "a")
 ```
 
-Rather than encumbering the constructor, it's better to put complicated checks in a separate function. Doing so allows you to cheaply create new objects when you know that the values are correct, and easily re-use the checks in other places.
+Rather than encumbering the constructor with complicated checks, it's better to put them in a separate function. Doing so allows you to cheaply create new objects when you know that the values are correct, and easily re-use the checks in other places. 
 
 ```{r, error = TRUE}
 validate_factor <- function(x) {
@@ -498,7 +498,7 @@ There are two wrinkles to be aware of when you create a new method:
 *   First, you should only ever write a method if you own the generic or the
     class. R will allow you to define a method even if you don't, but it is
     exceedingly bad manners. Instead, work with the author of either the 
-    generic or the class to add the method in his or her code.
+    generic or the class to add the method in their code.
 
 *   A method must have the same arguments as its generic. This is enforced in
     packages by `R CMD check`, but it's good practice even if you're not 

--- a/S3.Rmd
+++ b/S3.Rmd
@@ -9,7 +9,7 @@ source("common.R")
 
 S3 is R's first and simplest OO system. S3 is informal and ad hoc, but there is a certain elegance in its minimalism: you can't take away any part of it and still have a useful OO system. For these reasons, you should use it, unless you have a compelling reason to do otherwise. S3 is the only OO system used in the base and stats packages, and it's the most commonly used system in CRAN packages.
 
-S3 is very flexible, which means it allows you to do things that are quite ill-advised. If you're coming from a strict environment like Java this will seem pretty frightening, but it gives R programmers a tremendous amount of freedom.  It may be very difficult to prevent someone from doing something you don't want them to do, but your users will never be held back because there is something you haven't implemented yet. Since S3 has few built-in constraints, the key to its successful use is applying the constraints yourself. This chapter will therefore teach you the conventions you should (almost) always adhere to.
+S3 is very flexible, which means it allows you to do things that are quite ill-advised. If you're coming from a strict environment like Java this will seem pretty frightening, but it gives R programmers a tremendous amount of freedom.  It may be very difficult to prevent people from doing something you don't want them to do, but your users will never be held back because there is something you haven't implemented yet. Since S3 has few built-in constraints, the key to its successful use is applying the constraints yourself. This chapter will therefore teach you the conventions you should (almost) always follow.
 
 The goal of this chapter is to show you how the S3 system works, not how to use it effectively to create new classes and generics. I'd recommend coupling the theoretical knowledge from this chapter with the practical knowledge encoded in the [vctrs package](https://vctrs.r-lib.org).
 
@@ -52,7 +52,7 @@ library(sloop)
 \index{classes!S3}
 \indexc{class()}
 
-An S3 object is a base type with at least a "class" attribute (other attributes may be used to store other data). For example, take the factor. Its base type is the integer vector, it has a class attribute of "factor", and a levels attribute that stores the possible levels:
+An S3 object is a base type with at least a `class` attribute (other attributes may be used to store other data). For example, take the factor. Its base type is the integer vector, it has a `class` attribute of "factor", and a `levels` attribute that stores the possible levels:
 
 ```{r}
 f <- factor(c("a", "b", "c"))
@@ -61,7 +61,7 @@ typeof(f)
 attributes(f)
 ```
 
-You can get the "underlying" base type by `unclass()`ing it, which strips the class attribute, causing it to lose its special behaviour:
+You can get the underlying base type by `unclass()`ing it, which strips the class attribute, causing it to lose its special behaviour:
 
 ```{r}
 unclass(f)
@@ -127,7 +127,7 @@ s3_get_method(weighted.mean.Date)
 
 ### Exercises
 
-1.  Describe the difference between `t.test()` and `t.data.frame()`?
+1.  Describe the difference between `t.test()` and `t.data.frame()`.
     When is each function called?
 
 1.  Make a list of commonly used base R functions that contain `.` in their
@@ -211,8 +211,8 @@ To avoid foot-bullet intersections when creating your own class, I recommend tha
 * A low-level __constructor__, `new_myclass()`, that efficiently creates new
   objects with the correct structure.
 
-* A __validator__, `validate_myclass()`, that performs more expensive checks to 
-  ensure that the object has correct values.
+* A __validator__, `validate_myclass()`, that performs more computationally 
+  expensive checks to ensure that the object has correct values.
 
 * A user-friendly __helper__, `myclass()`, that provides a convenient way for
   others to create objects of your class.
@@ -223,7 +223,7 @@ You don't need a validator for very simple classes, and you can skip the helper 
 \index{S3!constructors}
 \index{constructors!S3}
 
-S3 doesn't provide a formal definition of a class, so it has no built-in way to ensure that all objects of a given class have the same structure (i.e. the same base type and the same attributes with the same types). Instead, you must enforce a consistent structure yourself by using a __constructor__.
+S3 doesn't provide a formal definition of a class, so it has no built-in way to ensure that all objects of a given class have the same structure (i.e. the same base type and the same attributes with the same types). Instead, you must enforce a consistent structure by using a __constructor__.
 
 The constructor should follow three principles:
 
@@ -233,7 +233,7 @@ The constructor should follow three principles:
 
 * Check the type of the base object and the types of each attribute.
 
-I'll illustrate these ideas by creating constructors for base classes[^base-constructors] that you're already familiar with. To start, lets make a constructor for the simplest S3 class: `Date`. A `Date` is just a double with a "Date" class attribute, and no additional attributes. This makes for a very simple constructor:
+I'll illustrate these ideas by creating constructors for base classes[^base-constructors] that you're already familiar with. To start, lets make a constructor for the simplest S3 class: `Date`. A `Date` is just a double with "Date" as its `class` attribute, and no additional attributes. This makes for a very simple constructor:
 
 [^base-constructors]: Recent versions of R have `.Date()`, `.difftime()`, `.POSIXct()`, and `.POSIXlt()` constructors but they are internal, not well documented, and do not follow the principles that I recommend.
 
@@ -249,7 +249,7 @@ new_Date(c(-1, 0, 1))
 
 The purpose of constructors is to help you, the developer. That means you can keep them simple, and you don't need to optimise error messages for public consumption. If you expect users to also create objects, you should create a friendly helper function, called `class_name()`, which I'll describe shortly.
 
-A slightly more complicated constructor is that for `difftime`, which is used to represent time differences. It is again built on a double, but has a units attribute that must take one of a small set of values:
+A slightly more complicated constructor is that for `difftime`, which is used to represent time differences. It is again built on a double, but has a `units` attribute that must take one of a small set of values:
 
 \indexc{difftime}
 ```{r}
@@ -267,7 +267,7 @@ new_difftime(c(1, 10, 3600), "secs")
 new_difftime(52, "weeks")
 ```
 
-The constructor is a developer function: it will be called in many places, by an experienced user. That means it's ok to trade a little safety in return for performance, and you should avoid potentially time-consuming checks in the constructor.
+The constructor is a developer function: it will be called in many places, by an experienced user. That means it's OK to trade a little safety in return for performance, and you should avoid potentially time-consuming checks in the constructor.
 
 ### Validators
 \index{S3!validators}
@@ -292,7 +292,7 @@ new_factor(1:5, "a")
 new_factor(0:1, "a")
 ```
 
-Rather than encumbering the constructor with complicated checks, it's better to put them in a separate function. Doing so allows you to cheaply create new objects when you know that the values are correct, and easily re-use the checks in other places.
+Rather than encumbering the constructor, it's better to put complicated checks in a separate function. Doing so allows you to cheaply create new objects when you know that the values are correct, and easily re-use the checks in other places.
 
 ```{r, error = TRUE}
 validate_factor <- function(x) {
@@ -449,7 +449,7 @@ my_new_generic <- function(x) {
 
 (If you wonder why we have to repeat `my_new_generic` twice, think back to Section \@ref(first-class-functions).)
 
-You don't pass any of the arguments of the generic to `UseMethod()`; it uses deep magic to pass to the method automatically. The precise process is complicated and frequently surprising, so you should avoid doing any computation in a generic. To learn the full details, carefully read the "technical details" section in `?UseMethod`.
+You don't pass any of the arguments of the generic to `UseMethod()`; it uses deep magic to pass to the method automatically. The precise process is complicated and frequently surprising, so you should avoid doing any computation in a generic. To learn the full details, carefully read the Technical Details section in `?UseMethod`.
 
 ### Method dispatch
 \index{S3!method dispatch}
@@ -498,7 +498,7 @@ There are two wrinkles to be aware of when you create a new method:
 *   First, you should only ever write a method if you own the generic or the
     class. R will allow you to define a method even if you don't, but it is
     exceedingly bad manners. Instead, work with the author of either the 
-    generic or the class to add the method in their code.
+    generic or the class to add the method in his or her code.
 
 *   A method must have the same arguments as its generic. This is enforced in
     packages by `R CMD check`, but it's good practice even if you're not 
@@ -551,9 +551,9 @@ There are two wrinkles to be aware of when you create a new method:
 ## Object styles
 \index{S3!object styles}
 
-So far I've focussed on "vector style" classes like `Date` and `factor`. These have the key property that `length(x)` represents the number of observations in the vector. There are three variants that do not have this property:
+So far I've focussed on vector style classes like `Date` and `factor`. These have the key property that `length(x)` represents the number of observations in the vector. There are three variants that do not have this property:
 
-*   "Record style" objects use a list of equal-length vectors to represent 
+*   Record style objects use a list of equal-length vectors to represent 
     individual components of the object. The best example of this is `POSIXlt`,
     which underneath the hood is a list of 11 date-time components like year, 
     month, and day. Record style classes override `length()` and subsetting 
@@ -583,7 +583,7 @@ So far I've focussed on "vector style" classes like `Date` and `factor`. These h
     ```
     \indexc{Date}
 
-*   Scalar objects typically use a list to represent a single "thing". 
+*   Scalar objects typically use a list to represent a single thing. 
     For example, an `lm` object is a list of length 12 but it represents one
     model.
     
@@ -600,7 +600,7 @@ So far I've focussed on "vector style" classes like `Date` and `factor`. These h
     
 [^s3-pairlist]: You can also build an object on top of a pairlist, but I have yet to find a good reason to do so.
 
-Unfortunately, describing the appropriate use of each of these object styles is beyond the scope of this book. However, you can learn more from the documentation of the vctrs package (<https://vctrs.r-lib.org>); the package also provides constructors and helper that make implementation of the different styles easier.
+Unfortunately, describing the appropriate use of each of these object styles is beyond the scope of this book. However, you can learn more from the documentation of the vctrs package (<https://vctrs.r-lib.org>); the package also provides constructors and helpers that make implementation of the different styles easier.
 
 ### Exercises
 
@@ -647,7 +647,7 @@ S3 classes can share behaviour through a mechanism called __inheritance__. Inher
 
 Before we continue we need a bit of vocabulary to describe the relationship between the classes that appear together in a class vector. We'll say that `ordered` is a __subclass__ of `factor` because it always appears before it in the class vector, and, conversely, we'll say `factor` is a __superclass__ of `ordered`. 
 
-S3 imposes no restrictions on the relationship between sub- and superclasses but your life will be easier if you impose some yourself. I recommend that you adhere to two simple principles when creating a subclass:
+S3 imposes no restrictions on the relationship between sub- and superclasses but your life will be easier if you impose some. I recommend that you adhere to two simple principles when creating a subclass:
 
 * The base type of the subclass should be that same as the superclass.
 
@@ -835,9 +835,9 @@ class(matrix(1:5))
 
 But unfortunately dispatch actually occurs on the __implicit class__, which has three components:
 
-* "array" or "matrix" (if the object has dimensions).
-* `typeof()` (with a few minor tweaks).
-* If it's "integer" or "double", "numeric".
+* The string "array" or "matrix" if the object has dimensions
+* The result of `typeof()` with a few minor tweaks
+* The string "numeric" if object is "integer" or "double"
 
 There is no base function that will compute the implicit class, but you can use `sloop::s3_class()`
 
@@ -922,7 +922,7 @@ Inside a group generic function a special variable `.Generic` provides the actua
 \index{double dispatch}
 \index{method dispatch!S3!double dispatch}
 
-Generics in the "Ops" group, which includes the two-argument arithmetic and boolean operators like `-` and `&`, implement a special type of method dispatch. They dispatch on the type of _both_ of the arguments, which is called __double dispatch__. This is necessary to preserve the commutative property of many operators, i.e. `a + b` should equal `b + a`. Take the following simple example:
+Generics in the Ops group, which includes the two-argument arithmetic and Boolean operators like `-` and `&`, implement a special type of method dispatch. They dispatch on the type of _both_ of the arguments, which is called __double dispatch__. This is necessary to preserve the commutative property of many operators, i.e. `a + b` should equal `b + a`. Take the following simple example:
 
 ```{r}
 date <- as.Date("2017-01-01")


### PR DESCRIPTION
* p. 297 Editor asks to change "stats" to "statistics". Left it as is because is the name of the package. 

* p. 298 Changed the names of attributes to monospace and kept the quotes around "factor". 

* p. 310 "It basically creates a vector of method names, paste0("generic", ".", c(class(x), "default")), and then". Should "generic" be quoted? 

* p. 310 Asks to remove quotes around "default". I think that "default class" (without quotes) implies that "default" is an adjective of "class" instead of being the name of the class.  