### PR TITLE
Metaprogramming introduction

### DIFF
--- a/Meta.Rmd
+++ b/Meta.Rmd
@@ -12,34 +12,34 @@ One of the most intriguing things about R is its ability to do __metaprogramming
 
 Closely related to metaprogramming is __non-standard evaluation__, NSE for short. This term, which is commonly used to describe the behaviour of R functions, is problematic in two ways. Firstly, NSE is actually a property of the argument (or arguments) of a function, so talking about NSE functions is a little sloppy. Secondly, it's confusing to define something by what it's not (standard), so in this book I'll introduce more precise vocabulary.
 
-Specifically, this book focuses on tidy evaluation (sometimes called tidy eval for short). Tidy evaluation is implemented in the rlang package [@rlang], and I'll use rlang extensively in these chapters. This will allow you to focus on the big ideas, without being distracted by the quirks of implementation that arise from R's history. After I introduce each big idea with rlang, I'll then circle back to talk about how those ideas are expressed in base R. This approach may seem backward to some, but it's like learning how to drive using an automatic transmission rather than a stick shift: it allows you to focus on the big picture before having to learn the details. This book focusses on the theoretical side of tidy evaluation, so you can fully understand how it works from the ground up. If you are looking for a more practical introduction, I recommend the "tidy evaluation book", <https://tidyeval.tidyverse.org>[^tidyeval-wip].
+Specifically, this book focuses on tidy evaluation (sometimes called tidy eval for short). Tidy evaluation is implemented in the rlang package [@rlang], and I'll use rlang extensively in these chapters. This will allow you to focus on the big ideas, without being distracted by the quirks of implementation that arise from R's history. After I introduce each big idea with rlang, I'll then circle back to talk about how those ideas are expressed in base R. This approach may seem backward to some, but it's like learning how to drive using an automatic transmission rather than a stick shift: it allows you to focus on the big picture before having to learn the details. This book focusses on the theoretical side of tidy evaluation, so you can fully understand how it works from the ground up. If you are looking for a more practical introduction, I recommend the tidy evaluation book at <https://tidyeval.tidyverse.org>[^tidyeval-wip].
 
 [^tidyeval-wip]: As I write this chapter, the tidy evaluation book is still a work-in-progress, but by the time you read this it will hopefully be finished.
 
 You'll learn about metaprogramming and tidy evaluation in the following five chapters:
 
-* In __Big picture__, Chapter \@ref(meta-big-picture), you'll get a sense of 
+* In Big picture, Chapter \@ref(meta-big-picture), you'll get a sense of 
   the whole metaprogramming story, briefly learning about each major component 
   and how they fit together to form a cohesive whole.
 
-* In __Expressions__, Chapter \@ref(expressions), you'll learn that all R code
+* In Expressions, Chapter \@ref(expressions), you'll learn that all R code
   can be described as a tree. You'll learn how to visualise these trees, how 
   the rules of R's grammar convert linear sequences of characters into these 
   trees, and how to use recursive functions to work with code trees.
 
-* In __Quasiquotation__, Chapter \@ref(quasiquotation), you'll learn to use
+* In Quasiquotation, Chapter \@ref(quasiquotation), you'll learn to use
   tools from rlang to capture ("quote") unevaluated function arguments. You'll
   also learn about quasiquotation, which provides a set of techniques to
   "unquote" input to make it possible to easily generate new trees from
   code fragments.
 
-* In __Evaluation__, Chapter \@ref(evaluation), you'll learn how to evaluate 
+* In Evaluation, Chapter \@ref(evaluation), you'll learn how to evaluate 
   captured code. Here you'll learn about an important data structure, the 
   __quosure__, which ensures correct evaluation by capturing both the code
   to evaluate, and the environment in which to evaluate it. This chapter will
   show you how to put all the pieces together to understand how NSE works in 
   base R, and how to write functions that work like `subset()`.
 
-* Finally, in __Translating R code__, Chapter \@ref(translation), you'll see
+* Finally, in Translating R code, Chapter \@ref(translation), you'll see
   how to combine first-class environments, lexical scoping, and metaprogramming
   to translate R code into other languages, namely HTML and LaTeX.

--- a/Meta.Rmd
+++ b/Meta.Rmd
@@ -19,7 +19,7 @@ Specifically, this book focuses on tidy evaluation (sometimes called tidy eval f
 You'll learn about metaprogramming and tidy evaluation in the following five chapters:
 
 * In Big picture, Chapter \@ref(meta-big-picture), you'll get a sense of 
-  the whole metaprogramming story, briefly learning about each major component 
+  the whole metaprogramming story, briefly learning about all major components 
   and how they fit together to form a cohesive whole.
 
 * In Expressions, Chapter \@ref(expressions), you'll learn that all R code
@@ -28,9 +28,9 @@ You'll learn about metaprogramming and tidy evaluation in the following five cha
   trees, and how to use recursive functions to work with code trees.
 
 * In Quasiquotation, Chapter \@ref(quasiquotation), you'll learn to use
-  tools from rlang to capture ("quote") unevaluated function arguments. You'll
+  tools from rlang to capture (quote) unevaluated function arguments. You'll
   also learn about quasiquotation, which provides a set of techniques to
-  "unquote" input to make it possible to easily generate new trees from
+  unquote input to make it possible to easily generate new trees from
   code fragments.
 
 * In Evaluation, Chapter \@ref(evaluation), you'll learn how to evaluate 


### PR DESCRIPTION
I found that chapter overviews in each introductory part do not share the same style. 
* In introduction to Foundations, is "You use vectors every day in R, so Chapter 3 will dive..."
* In Functional programming is "Chapter 9 shows you how to... "
* In Metaprogramming is "In Big picture, Chapter 17, you’ll get..."
* In Techniques is in paragraphs instead of bullet points.

I don't know if this is intentional but it may be worth revising. 