### PR TITLE
Move a sidenote to another section in Evaluation.Rmd

### DIFF
--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -82,24 +82,6 @@ eval(print(x + 1), env(x = 1000))
 eval(expr(print(x + 1)), env(x = 1000))
 ```
 
-
-::: sidebar
-**Expression vectors**
-\index{expression vectors}
-
-`base::eval()` has special behaviour for expression _vectors_, evaluating each component in turn. This makes for a very compact implementation of `source2()` because `base::parse()` also returns an expression object:
-
-```{r}
-source3 <- function(file, env = parent.frame()) {
-  lines <- parse(file)
-  res <- eval(lines, envir = env)
-  invisible(res)
-}
-```
-
-While `source3()` is considerably more concise than `source2()`, this is the only advantage to expression vectors. Overall I don't believe this benefit outweighs the cost of introducing a new data structure, and hence this book avoids the use of expression vectors.
-:::
-
 Now that you've seen the basics, let's explore some applications. We'll focus primarily on base R functions that you might have used before, reimplementing the underlying principles using rlang.
 
 ### Application: `local()`
@@ -163,6 +145,25 @@ source2 <- function(path, env = caller_env()) {
 ```
 
 The real `source()` is considerably more complicated because it can `echo` input and output, and has many other settings that control its behaviour.
+
+
+::: sidebar
+**Expression vectors**
+\index{expression vectors}
+
+`base::eval()` has special behaviour for expression _vectors_, evaluating each component in turn. This makes for a very compact implementation of `source2()` because `base::parse()` also returns an expression object:
+
+```{r}
+source3 <- function(file, env = parent.frame()) {
+  lines <- parse(file)
+  res <- eval(lines, envir = env)
+  invisible(res)
+}
+```
+
+While `source3()` is considerably more concise than `source2()`, this is the only advantage to expression vectors. Overall I don't believe this benefit outweighs the cost of introducing a new data structure, and hence this book avoids the use of expression vectors.
+:::
+
 
 ### Gotcha: `function()`
 \index{evaluation!functions}


### PR DESCRIPTION
I think that this sidenote is not in the right place. It refers to source2() so I moved it to where I suppose it belongs and makes sense to me, in section 20.2.2 . I appended it to the end of the section, but it could go before the last paragraph as well.