### PR TITLE
Global changes

### DIFF
--- a/C-interface.Rmd
+++ b/C-interface.Rmd
@@ -6,7 +6,7 @@ library(inline)
 
 Reading R's source code is an extremely powerful technique for improving your programming skills. However, many base R functions, and many functions in older packages, are written in C. It's useful to be able to figure out how those functions work, so this chapter will introduce you to R's C API. You'll need some basic C knowledge, which you can get from a standard C text (e.g., [_The C Programming Language_](http://amzn.com/0131101633?tag=devtools-20) by Kernigan and Ritchie), or from [Rcpp](#rcpp). You'll need a little patience, but it is possible to read R's C source code, and you will learn a lot doing it. \index{C}
 
-The contents of this chapter draw heavily from Section 5 ("System and foreign language interfaces") of [Writing R extensions](http://cran.r-project.org/doc/manuals/R-exts.html), but focus on best practices and modern tools. This means it does not cover the old `.C` interface, the old API defined in `Rdefines.h`, or rarely used language features. To see R's complete C API, look at the header file `Rinternals.h`. It's easiest to find and display this file from within R:
+The contents of this chapter draw heavily from Section 5 ("System and foreign language interfaces") of [_Writing R extensions_](http://cran.r-project.org/doc/manuals/R-exts.html), but focus on best practices and modern tools. This means it does not cover the old `.C` interface, the old API defined in `Rdefines.h`, or rarely used language features. To see R's complete C API, look at the header file `Rinternals.h`. It's easiest to find and display this file from within R:
 
 ```{r, eval = FALSE}
 rinternals <- file.path(R.home("include"), "Rinternals.h")

--- a/Control-flow.Rmd
+++ b/Control-flow.Rmd
@@ -378,7 +378,7 @@ Generally speaking you shouldn't need to use for loops for data analysis tasks, 
     }
     ```
 
-## Quiz Answers {#control-flow-answers}
+## Quiz answers {#control-flow-answers}
 
 * `if` works with scalars; `ifelse()` works with vectors.
 

--- a/Expressions.Rmd
+++ b/Expressions.Rmd
@@ -380,6 +380,10 @@ The following table summarises the appearance of the different expression subtyp
 
 Both base R and rlang provide functions for testing for each type of input, although the types covered are slightly different. You can easily tell them apart because all the base functions start with `is.` and the rlang functions start with `is_`.
 
+\newpage
+
+<!-- New page so that there's no beak inside the table -->
+
 |                   | base                | rlang                    |
 |-------------------|---------------------|--------------------------|
 | Scalar constant   | —                   | `is_syntactic_literal()` |

--- a/Foundations.Rmd
+++ b/Foundations.Rmd
@@ -4,37 +4,37 @@
 
 To start your journey in mastering R, the following six chapters will help you learn the foundational components of R. I expect that you've already seen many of these pieces before, but you probably have not studied them deeply. To help check your existing knowledge, each chapter starts with a quiz; if you get all the questions right, feel free to skip to the next chapter!
 
-1.  In Chapter \@ref(names-values), you'll learn about an important distinction
+1.  Chapter \@ref(names-values), teaches you about an important distinction
     that you probably haven't thought deeply about: the difference between an 
     object and its name. Improving your mental model here will help you make 
     better predictions about when R copies data and hence which basic 
     operations are cheap and which are expensive.
    
-1.  You use vectors every day in R, so Chapter \@ref(vectors-chap) will dive 
-    into the details, helping you learn how the different types of vector fit 
+1.  Chapter \@ref(vectors-chap) dives into the details of vectors, helping you 
+    learn how the different types of vector fit 
     together. You'll also learn about attributes, which allow you to store 
     arbitrary metadata, and form the basis for two of R's object-oriented 
     programming toolkits.
     
-1.  To write clear, concise, and efficient R code it is important to fully 
-    appreciate the power of subsetting as described in Chapter 
-    \@ref(subsetting). Understanding the fundamental components will allow you 
-    to solve new problems by combining the building blocks in novel ways.
+1.  Chapter \@ref(subsetting) describes how to use subsetting properly to write 
+    clear, concise, and efficient R code. Understanding the fundamental 
+    components will allow you to solve new problems by combining the building 
+    blocks in novel ways.
 
-1.  The tools of control flow allow you to only execute code under certain
-    conditions, or to repeatedly execute code with changing inputs. In Chapter
-    \@ref(control-flow), you'll learn the important `if` and `for` constructs,
-    as well as related tools like `switch()` and `while`.
+1.  Chapter \@ref(control-flow) presents tools of control flow that allow you to
+    only execute code under certain conditions, or to repeatedly execute code 
+    with changing inputs: the important `if` and `for` constructs, as well as 
+    related tools like `switch()` and `while`.
 
-1.  Functions are the most important building block of R code, and in Chapter
-    \@ref(functions), you'll learn exactly how they work, including the 
+1.  Chapter \@ref(functions) deals with functions -- the most important builing 
+    blocks of R code. You'll learn exactly how they work, including the 
     scoping rules, which govern how R looks up values from names. You'll also 
     learn more of the details behind lazy evaluation, and how you can 
     control what happens when you exit a function.
     
-1.  In Chapter \@ref(environments), you'll learn about a data structure that
-    is crucial for understanding how R works, but quite unimportant for data 
-    analysis: the environment. Environments are the data structure that binds 
+1.  Chapter \@ref(environments) describes a data structure that is crucial for 
+    understanding how R works, but quite unimportant for data analysis: the 
+    environment. Environments are the data structure that binds 
     names to values, and they power important tools like package namespaces. 
     Unlike most programming languages, environments in R are "first class" 
     which means that you can manipulate them just like other objects.

--- a/Foundations.Rmd
+++ b/Foundations.Rmd
@@ -4,7 +4,7 @@
 
 To start your journey in mastering R, the following six chapters will help you learn the foundational components of R. I expect that you've already seen many of these pieces before, but you probably have not studied them deeply. To help check your existing knowledge, each chapter starts with a quiz; if you get all the questions right, feel free to skip to the next chapter!
 
-1.  Chapter \@ref(names-values), teaches you about an important distinction
+1.  Chapter \@ref(names-values) teaches you about an important distinction
     that you probably haven't thought deeply about: the difference between an 
     object and its name. Improving your mental model here will help you make 
     better predictions about when R copies data and hence which basic 
@@ -16,17 +16,17 @@ To start your journey in mastering R, the following six chapters will help you l
     arbitrary metadata, and form the basis for two of R's object-oriented 
     programming toolkits.
     
-1.  Chapter \@ref(subsetting) describes how to use subsetting properly to write 
+1.  Chapter \@ref(subsetting) describes how to use subsetting to write 
     clear, concise, and efficient R code. Understanding the fundamental 
     components will allow you to solve new problems by combining the building 
     blocks in novel ways.
 
 1.  Chapter \@ref(control-flow) presents tools of control flow that allow you to
     only execute code under certain conditions, or to repeatedly execute code 
-    with changing inputs: the important `if` and `for` constructs, as well as 
+    with changing inputs. These include important `if` and `for` constructs, as well as 
     related tools like `switch()` and `while`.
 
-1.  Chapter \@ref(functions) deals with functions -- the most important builing 
+1.  Chapter \@ref(functions) deals with functions, the most important building 
     blocks of R code. You'll learn exactly how they work, including the 
     scoping rules, which govern how R looks up values from names. You'll also 
     learn more of the details behind lazy evaluation, and how you can 

--- a/Functionals.Rmd
+++ b/Functionals.Rmd
@@ -21,10 +21,10 @@ cols("#8DD3FB")
 ## Introduction
 \index{functionals}
 
-> "To become significantly more reliable, code must become more transparent.
+> To become significantly more reliable, code must become more transparent.
 > In particular, nested conditions and loops must be viewed with great
 > suspicion. Complicated control flows confuse programmers. Messy code often
-> hides bugs."
+> hides bugs.
 >
 > --- Bjarne Stroustrup
 

--- a/Introduction.Rmd
+++ b/Introduction.Rmd
@@ -133,9 +133,9 @@ After reading this book, you will:
 
 ## What you will not learn
 
-This book is about R the programming language, not R the data analysis tool. If you are looking to improve your data science skills, I instead recommend that you learn about the [tidyverse](https://www.tidyverse.org/), a collection of consistent packages developed by me and my colleagues. In this book you'll learn the techniques used to develop the tidyverse packages; if you want to instead learn how to use them, I recommend ["R for Data Science"](http://r4ds.had.co.nz/).
+This book is about R the programming language, not R the data analysis tool. If you are looking to improve your data science skills, I instead recommend that you learn about the [tidyverse](https://www.tidyverse.org/), a collection of consistent packages developed by me and my colleagues. In this book you'll learn the techniques used to develop the tidyverse packages; if you want to instead learn how to use them, I recommend [_R for Data Science_](http://r4ds.had.co.nz/).
 
-If you want to share your R code with others, you will need to make an R package. This allows you to bundle code along with documentation and unit tests, and easily distribute it via CRAN. In my opinion, the easiest way to develop packages is with [devtools](http://devtools.r-lib.org), [roxygen2](http://klutometis.github.io/roxygen/), [testthat](http://testthat.r-lib.org), and [usethis](http://usethis.r-lib.org). You can learn about using these packages to make your own package in ["R packages"](http://r-pkgs.had.co.nz/).
+If you want to share your R code with others, you will need to make an R package. This allows you to bundle code along with documentation and unit tests, and easily distribute it via CRAN. In my opinion, the easiest way to develop packages is with [devtools](http://devtools.r-lib.org), [roxygen2](http://klutometis.github.io/roxygen/), [testthat](http://testthat.r-lib.org), and [usethis](http://usethis.r-lib.org). You can learn about using these packages to make your own package in [_R packages_](http://r-pkgs.had.co.nz/).
 
 ## Meta-techniques {#meta-techniques}
 
@@ -149,13 +149,13 @@ A scientific mindset is extremely helpful when learning R. If you don't understa
 
 Because the R community mostly consists of data scientists, not computer scientists, there are relatively few books that go deep in the technical underpinnings of R. In my personal journey to understand R, I've found it particularly helpful to use resources from other programming languages. R has aspects of both functional and object-oriented (OO) programming languages. Learning how these concepts are expressed in R will help you leverage your existing knowledge of other programming languages, and will help you identify areas where you can improve.
 
-To understand why R's object systems work the way they do, I found "The Structure and Interpretation of Computer Programs"[^SICP] [@SICP] (SICP) to be particularly helpful. It's a concise but deep book, and after reading it, I felt for the first time that I could actually design my own object-oriented system. The book was my first introduction to the encapsulated paradigm of object-oriented programming found in R, and it helped me understand the strengths and weaknesses of this system. SICP also teaches the functional mindset where you create functions that are simple individually, and which become powerful when composed together.
+To understand why R's object systems work the way they do, I found _The Structure and Interpretation of Computer Programs_[^SICP] [@SICP] (SICP) to be particularly helpful. It's a concise but deep book, and after reading it, I felt for the first time that I could actually design my own object-oriented system. The book was my first introduction to the encapsulated paradigm of object-oriented programming found in R, and it helped me understand the strengths and weaknesses of this system. SICP also teaches the functional mindset where you create functions that are simple individually, and which become powerful when composed together.
 
 [^SICP]: You can read it online for free at <https://mitpress.mit.edu/sites/default/files/sicp/full-text/book/book.html>
 
-To understand the trade-offs that R has made compared to other programming languages, I found "Concepts, Techniques and Models of Computer Programming" [@ctmcp] extremely helpful. It helped me understand that R's copy-on-modify semantics make it substantially easier to reason about code, and that while its current implementation is not particularly efficient, it is a solvable problem.
+To understand the trade-offs that R has made compared to other programming languages, I found _Concepts, Techniques and Models of Computer Programming_ [@ctmcp] extremely helpful. It helped me understand that R's copy-on-modify semantics make it substantially easier to reason about code, and that while its current implementation is not particularly efficient, it is a solvable problem.
 
-If you want to learn to be a better programmer, there's no place better to turn than "The Pragmatic Programmer" [@pragprog]. This book is language agnostic, and provides great advice for how to be a better programmer.
+If you want to learn to be a better programmer, there's no place better to turn than _The Pragmatic Programmer_ [@pragprog]. This book is language agnostic, and provides great advice for how to be a better programmer.
 
 ## Getting help {#getting-help}
 \index{help}

--- a/Meta.Rmd
+++ b/Meta.Rmd
@@ -27,18 +27,18 @@ You'll learn about metaprogramming and tidy evaluation in the following five cha
     grammar convert linear sequences of characters into these trees, and how to 
     use recursive functions to work with code trees.
 
-1.  Chapter \@ref(quasiquotation) presents tools from rlang you can use to 
+1.  Chapter \@ref(quasiquotation) presents tools from rlang that you can use to 
     capture (quote) unevaluated function arguments. You'll also learn about
     quasiquotation, which provides a set of techniques to unquote input to make 
     it possible to easily generate new trees from code fragments.
 
-1.  Chapter \@ref(evaluation) moves to evaluating captured code. Here you'll 
+1.  Chapter \@ref(evaluation) moves on to evaluating captured code. Here you'll 
     learn about an important data structure, the  __quosure__, which ensures 
     correct evaluation by capturing both the code to evaluate, and the 
     environment in which to evaluate it. This chapter will show you how to put 
     all the pieces together to understand how NSE works in base R, and how to 
     write functions that work like `subset()`.
 
-1.  Chapter \@ref(translation) finally combines first-class environments, lexical 
+1.  Chapter \@ref(translation) finishes up by combining first-class environments, lexical 
     scoping, and metaprogramming to translate R code into other languages, 
     namely HTML and LaTeX.

--- a/Meta.Rmd
+++ b/Meta.Rmd
@@ -18,28 +18,27 @@ Specifically, this book focuses on tidy evaluation (sometimes called tidy eval f
 
 You'll learn about metaprogramming and tidy evaluation in the following five chapters:
 
-* In Big picture, Chapter \@ref(meta-big-picture), you'll get a sense of 
-  the whole metaprogramming story, briefly learning about all major components 
-  and how they fit together to form a cohesive whole.
+1.  Chapter \@ref(meta-big-picture) gives a high level description of the whole 
+    metaprogramming story, briefly learning about all major components 
+    and how they fit together to form a cohesive whole.
 
-* In Expressions, Chapter \@ref(expressions), you'll learn that all R code
-  can be described as a tree. You'll learn how to visualise these trees, how 
-  the rules of R's grammar convert linear sequences of characters into these 
-  trees, and how to use recursive functions to work with code trees.
+1.  Chapter \@ref(expressions) shows that that all R code can be described as a 
+    tree. You'll learn how to visualise these trees, how the rules of R's 
+    grammar convert linear sequences of characters into these trees, and how to 
+    use recursive functions to work with code trees.
 
-* In Quasiquotation, Chapter \@ref(quasiquotation), you'll learn to use
-  tools from rlang to capture (quote) unevaluated function arguments. You'll
-  also learn about quasiquotation, which provides a set of techniques to
-  unquote input to make it possible to easily generate new trees from
-  code fragments.
+1.  Chapter \@ref(quasiquotation) presents tools from rlang you can use to 
+    capture (quote) unevaluated function arguments. You'll also learn about
+    quasiquotation, which provides a set of techniques to unquote input to make 
+    it possible to easily generate new trees from code fragments.
 
-* In Evaluation, Chapter \@ref(evaluation), you'll learn how to evaluate 
-  captured code. Here you'll learn about an important data structure, the 
-  __quosure__, which ensures correct evaluation by capturing both the code
-  to evaluate, and the environment in which to evaluate it. This chapter will
-  show you how to put all the pieces together to understand how NSE works in 
-  base R, and how to write functions that work like `subset()`.
+1.  Chapter \@ref(evaluation) moves to evaluating captured code. Here you'll 
+    learn about an important data structure, the  __quosure__, which ensures 
+    correct evaluation by capturing both the code to evaluate, and the 
+    environment in which to evaluate it. This chapter will show you how to put 
+    all the pieces together to understand how NSE works in base R, and how to 
+    write functions that work like `subset()`.
 
-* Finally, in Translating R code, Chapter \@ref(translation), you'll see
-  how to combine first-class environments, lexical scoping, and metaprogramming
-  to translate R code into other languages, namely HTML and LaTeX.
+1.  Chapter \@ref(translation) finally combines first-class environments, lexical 
+    scoping, and metaprogramming to translate R code into other languages, 
+    namely HTML and LaTeX.

--- a/Names-values.Rmd
+++ b/Names-values.Rmd
@@ -738,7 +738,7 @@ This number won't agree with the amount of memory reported by your operating sys
 1. R counts the memory occupied by objects but there may be empty gaps due to 
    deleted objects. This problem is known as memory fragmentation.
 
-## Quiz Answers {#names-values-answers}
+## Quiz answers {#names-values-answers}
 
 1.  You must quote non-syntactic names with backticks: `` ` ``: for example,
     the variables `1`, `2`, and `3`.

--- a/Names-values.Rmd
+++ b/Names-values.Rmd
@@ -82,7 +82,7 @@ library(lobstr)
 
 ### Sources {-}
 
-The details of R's memory management are not documented in a single place. Much of the information in this chapter was gleaned from a close reading of the documentation (particularly `?Memory` and `?gc`), the [memory profiling](http://cran.r-project.org/doc/manuals/R-exts.html#Profiling-R-code-for-memory-use) section of "Writing R extensions" [@r-exts], and the [SEXPs](http://cran.r-project.org/doc/manuals/R-ints.html#SEXPs) section of "R internals" [@r-ints]. The rest I figured out by reading the C source code, performing small experiments, and asking questions on R-devel. Any mistakes are entirely mine.
+The details of R's memory management are not documented in a single place. Much of the information in this chapter was gleaned from a close reading of the documentation (particularly `?Memory` and `?gc`), the [memory profiling](http://cran.r-project.org/doc/manuals/R-exts.html#Profiling-R-code-for-memory-use) section of _Writing R extensions_ [@r-exts], and the [SEXPs](http://cran.r-project.org/doc/manuals/R-ints.html#SEXPs) section of _R internals_ [@r-ints]. The rest I figured out by reading the C source code, performing small experiments, and asking questions on R-devel. Any mistakes are entirely mine.
 
 ## Binding basics
 \index{bindings|seealso {assignment}}

--- a/OO.Rmd
+++ b/OO.Rmd
@@ -49,6 +49,22 @@ Generally in R, functional programming is much more important than object-orient
 
 The goal of this brief introductory chapter is to give you some important vocabulary and some tools to identify OOP systems in the wild. The following four chapters (Base types, S3, R6, and S4) then dive into the details of R's OOP systems. 
 
+
+1.  Chapter \@ref(base-types) first details the basic types upon which the more
+    complex objects are built. 
+    
+1.  Chapter \@ref(s3) introduces S3, the simplest and most commonly used
+    OO system.
+  
+1.  Chapter \@ref(r6) introduces R6, which is a radically different OO system.
+
+1.  Chapter \@ref(s4) introduces S4, which is similar to S3 but more formal and 
+    thus stricter. 
+    
+1.  Chapter \@ref(oo-tradeoffs) finally compares these three main OO systems. By
+    understanding the trade-offs of each system you can appreciate when to use 
+    one or the other. 
+
 This book focusses on the mechanics of OOP, not its effective use, and it may be challenging to fully understand if you have not done object-oriented programming before. You might wonder why I chose not to provide more immediately useful coverage. I have focussed on mechanics here because they need to be well described somewhere (writing these chapters required a considerable amount of reading, exploration, and synthesis on my behalf), and using OOP effectively is sufficiently complex to require book-length treatment; there's simply not enough room in Advanced R to cover it in the depth required.
 
 ## OOP systems {-}
@@ -151,18 +167,3 @@ otype(mle_obj)
 
 Use this function to figure out which chapter to read to understand how to work with an existing object.
 
-
-1.  Chapter \@ref(base-types) first details the basic types upon which the more
-    complex objects are built. 
-    
-1.  Chapter \@ref(s3) introduces S3, the simplest and most commonly used
-    OO system.
-  
-1.  Chapter \@ref(r6) introduces R6, which is a radically different OO system.
-
-1.  Chapter \@ref(s4) introduces S4, which is similar to S3 but more formal and 
-    thus stricter. 
-    
-1.  Chapter \@ref(oo-tradeoffs) finally compares these three main OO systems. By
-    understanding the trade-offs of each system you can appreciate when to use 
-    one or the other. 

--- a/OO.Rmd
+++ b/OO.Rmd
@@ -158,7 +158,7 @@ Use this function to figure out which chapter to read to understand how to work 
 1.  Chapter \@ref(s3) introduces S3, which is the most simple and commonly used 
     OO system.
   
-1.  Chapter \@ref(r6) introduces R4, which is a radically different OO system.
+1.  Chapter \@ref(r6) introduces R6, which is a radically different OO system.
 
 1.  Chapter \@ref(s4) introduces S4, which is similar to S3 but more formal and 
     thus stricter. 

--- a/OO.Rmd
+++ b/OO.Rmd
@@ -155,7 +155,7 @@ Use this function to figure out which chapter to read to understand how to work 
 1.  Chapter \@ref(base-types) first details the basic types upon which the more
     complex objects are built. 
     
-1.  Chapter \@ref(s3) introduces S3, which is the most simple and commonly used 
+1.  Chapter \@ref(s3) introduces S3, the simplest and most commonly used
     OO system.
   
 1.  Chapter \@ref(r6) introduces R6, which is a radically different OO system.

--- a/OO.Rmd
+++ b/OO.Rmd
@@ -150,3 +150,19 @@ otype(mle_obj)
 ```
 
 Use this function to figure out which chapter to read to understand how to work with an existing object.
+
+
+1.  Chapter \@ref(base-types) first details the basic types upon which the more
+    complex objects are built. 
+    
+1.  Chapter \@ref(s3) introduces S3, which is the most simple and commonly used 
+    OO system.
+  
+1.  Chapter \@ref(r6) introduces R4, which is a radically different OO system.
+
+1.  Chapter \@ref(s4) introduces S4, which is similar to S3 but more formal and 
+    thus stricter. 
+    
+1.  Chapter \@ref(oo-tradeoffs) finally compares these three main OO systems. By
+    understanding the trade-offs of each system you can appreciate when to use 
+    one or the other. 

--- a/Perf-improve.Rmd
+++ b/Perf-improve.Rmd
@@ -329,7 +329,7 @@ Vectorisation won't solve every problem, and rather than torturing an existing a
 \index{loops!avoiding copies in}
 \indexc{paste()}
 
-A pernicious source of slow R code is growing an object with a loop. Whenever you use `c()`, `append()`, `cbind()`, `rbind()`, or `paste()` to create a bigger object, R must first allocate space for the new object and then copy the old object to its new home. If you're repeating this many times, like in a for loop, this can be quite expensive. You've entered Circle 2 of the ["R inferno"](http://www.burns-stat.com/pages/Tutor/R_inferno.pdf). 
+A pernicious source of slow R code is growing an object with a loop. Whenever you use `c()`, `append()`, `cbind()`, `rbind()`, or `paste()` to create a bigger object, R must first allocate space for the new object and then copy the old object to its new home. If you're repeating this many times, like in a for loop, this can be quite expensive. You've entered Circle 2 of the [_R inferno_](http://www.burns-stat.com/pages/Tutor/R_inferno.pdf). 
 
 You saw one example of this type of problem in Section \@ref(memory-profiling), so here I'll show a slightly more complex example of the same basic issue. We first generate some random strings, and then combine them either iteratively with a loop using `collapse()`, or in a single pass using `paste()`. Note that the performance of `collapse()` gets relatively worse as the number of strings grows: combining 100 strings takes almost 30 times longer than combining 10 strings.
 
@@ -361,7 +361,7 @@ Modifying an object in a loop, e.g., `x[i] <- y`, can also create a copy, depend
 
 ## Case study: t-test {#t-test}
 
-The following case study shows how to make t-tests faster using some of the techniques described above. It's based on an example in ["Computing thousands of test statistics simultaneously in R"](http://stat-computing.org/newsletter/issues/scgn-18-1.pdf) by Holger Schwender and Tina Müller. I thoroughly recommend reading the paper in full to see the same idea applied to other tests.
+The following case study shows how to make t-tests faster using some of the techniques described above. It's based on an example in [_Computing thousands of test statistics simultaneously in R_](http://stat-computing.org/newsletter/issues/scgn-18-1.pdf) by Holger Schwender and Tina Müller. I thoroughly recommend reading the paper in full to see the same idea applied to other tests.
 
 Imagine we have run 1000 experiments (rows), each of which collects data on 50 individuals (columns). The first 25 individuals in each experiment are assigned to group 1 and the rest to group 2. We'll first generate some random data to represent this problem:
 
@@ -455,7 +455,7 @@ Being able to write fast R code is part of being a good R programmer. Beyond the
   problems other people have struggled with, and how they have made their
   code faster.
 
-* Read other R programming books, like "The Art of R Programming" 
+* Read other R programming books, like _The Art of R Programming_ 
   [@art-r-prog] or Patrick Burns'
   [_R Inferno_](http://www.burns-stat.com/documents/books/the-r-inferno/) to
   learn about common traps.
@@ -467,10 +467,10 @@ Being able to write fast R code is part of being a good R programmer. Beyond the
   Coursera.
   
 * Learn how to parallelise your code. Two places to start are
-  "Parallel R" [@parallel-r] and "Parallel Computing for Data Science"
+  _Parallel R_ [@parallel-r] and _Parallel Computing for Data Science_
   [@parcomp-ds].
 
-* Read general books about optimisation like "Mature optimisation" [@mature-opt]
-  or the "Pragmatic Programmer" [@pragprog].
+* Read general books about optimisation like _Mature optimisation_ [@mature-opt]
+  or the _Pragmatic Programmer_ [@pragprog].
   
 You can also reach out to the community for help. StackOverflow can be a useful resource. You'll need to put some effort into creating an easily digestible example that also captures the salient features of your problem. If your example is too complex, few people will have the time and motivation to attempt a solution. If it's too simple, you'll get answers that solve the toy problem but not the real problem. If you also try to answer questions on StackOverflow, you'll quickly get a feel for what makes a good question.  

--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -641,7 +641,7 @@ bquote(-.(xyz) / 2)
   is crucial for functions that evaluate code in the context of a data frame,
   like `subset()` and friends.
 
-Instead functions that quote an argument use some other technique to allow indirect specification. Rather than using use unquoting all base R approaches selectively turn quoting off, so I call them __non-quoting__ techniques.
+Base functions that quote an argument use some other technique to allow indirect specification. Base R approaches selectively turn quoting off, rather than using unquoting, so I call them __non-quoting__ techniques.
 
 ```{r, eval = FALSE, include = FALSE}
 call <- names(pryr::find_uses("package:base", "match.call"))

--- a/Rcpp.Rmd
+++ b/Rcpp.Rmd
@@ -1148,7 +1148,7 @@ Other resources I've found helpful in learning C++ are:
   which provides a more technical, but still concise, description of 
   important STL concepts. (Follow the links under notes.)
 
-Writing performance code may also require you to rethink your basic approach: a solid understanding of basic data structures and algorithms is very helpful here. That's beyond the scope of this book, but I'd suggest the "Algorithm Design Manual" [@alg-design-man], MIT's [_Introduction to Algorithms_](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-046j-introduction-to-algorithms-sma-5503-fall-2005/), _Algorithms_ by Robert Sedgewick and Kevin Wayne which has a free [online textbook](http://algs4.cs.princeton.edu/home/) and a matching [Coursera course](https://www.coursera.org/learn/algorithms-part1).
+Writing performance code may also require you to rethink your basic approach: a solid understanding of basic data structures and algorithms is very helpful here. That's beyond the scope of this book, but I'd suggest the _Algorithm Design Manual_ [@alg-design-man], MIT's [_Introduction to Algorithms_](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-046j-introduction-to-algorithms-sma-5503-fall-2005/), _Algorithms_ by Robert Sedgewick and Kevin Wayne which has a free [online textbook](http://algs4.cs.princeton.edu/home/) and a matching [Coursera course](https://www.coursera.org/learn/algorithms-part1).
 
 ## Acknowledgments
 

--- a/Rcpp.Rmd
+++ b/Rcpp.Rmd
@@ -641,9 +641,7 @@ LogicalVector is_naC(NumericVector x) {
 is_naC(c(NA, 5.4, 3.2, NA))
 ```
 
-<!-- Is not clear what "sugar function" means. -->
-
-Another alternative is the sugar function `is_na()`, which takes a vector and returns a logical vector.
+Another alternative is the function `is_na()`, which takes a vector and returns a logical vector.
 
 ```{r, engine = "Rcpp"}
 #include <Rcpp.h>

--- a/Rcpp.Rmd
+++ b/Rcpp.Rmd
@@ -619,44 +619,6 @@ List missing_sampler() {
 str(missing_sampler())
 ```
 
-To check if a value in a vector is missing, use the class method `::is_na()`:
-
-```{r, engine = "Rcpp"}
-#include <Rcpp.h>
-using namespace Rcpp;
-
-// [[Rcpp::export]]
-LogicalVector is_naC(NumericVector x) {
-  int n = x.size();
-  LogicalVector out(n);
-
-  for (int i = 0; i < n; ++i) {
-    out[i] = NumericVector::is_na(x[i]);
-  }
-  return out;
-}
-```
-
-```{r}
-is_naC(c(NA, 5.4, 3.2, NA))
-```
-
-Another alternative is the function `is_na()`, which takes a vector and returns a logical vector.
-
-```{r, engine = "Rcpp"}
-#include <Rcpp.h>
-using namespace Rcpp;
-
-// [[Rcpp::export]]
-LogicalVector is_naC2(NumericVector x) {
-  return is_na(x);
-}
-```
-
-```{r}
-is_naC2(c(NA, 5.4, 3.2, NA))
-```
-
 ### Exercises
 
 1. Rewrite any of the functions from the first exercise of 

--- a/S4.Rmd
+++ b/S4.Rmd
@@ -58,8 +58,8 @@ As you move towards more advanced usage, you will need to piece together needed 
     answered on [stackoverflow][SO-Morgan].
 
 *   John Chambers is the author of the S4 system, and provides an overview      
-    of its motivation and historical context in "Object-oriented programming,
-    functional programming and R" [@chambers-2014]. For a fuller exploration
+    of its motivation and historical context in _Object-oriented programming,
+    functional programming and R_ [@chambers-2014]. For a fuller exploration
     of S4, see his book _Software for Data Analysis_ [@s4da].
 
 ### Prerequisites {-}

--- a/Subsetting.Rmd
+++ b/Subsetting.Rmd
@@ -341,8 +341,8 @@ There are two other subsetting operators: `[[` and `$`. `[[` is used for extract
 
 `[[` is most important when working with lists because subsetting a list with `[` always returns a smaller list. To help make this easier to understand we can use a metaphor:
 
->  "If list `x` is a train carrying objects, then `x[[5]]` is
-> the object in car 5; `x[4:6]` is a train of cars 4-6." 
+>  If list `x` is a train carrying objects, then `x[[5]]` is
+> the object in car 5; `x[4:6]` is a train of cars 4-6.
 >
 > --- \@RLangTip, <https://twitter.com/RLangTip/status/268375867468681216>
 

--- a/Subsetting.Rmd
+++ b/Subsetting.Rmd
@@ -753,7 +753,7 @@ In general, avoid switching from logical to integer subsetting unless you want, 
     
 1.  How could you put the columns in a data frame in alphabetical order?
 
-## Quiz Answers {#subsetting-answers}
+## Quiz answers {#subsetting-answers}
 
 1.  Positive integers select elements at specific positions, negative integers
     drop elements; logical vectors keep elements at positions corresponding to

--- a/Techniques.Rmd
+++ b/Techniques.Rmd
@@ -2,8 +2,12 @@
 
 # Introduction {#techniques .unnumbered}
 
-The final four chapters cover two general programming techniques: finding and fixing bugs, and finding and fixing performance issues.
+The final four chapters cover two general programming techniques: finding and fixing bugs, and finding and fixing performance issues. Tools to measure and improve performance are particularly important because R is not a fast language. This is not an accident: R was purposely designed to make interactive data analysis easier for humans, not to make computers as fast as possible. While R is slow compared to other programming languages, for most purposes, it's fast enough. These chapters help you handle the cases where R is no longer fast enough, either by improving the performance of your R code, or by switching to a language, C++, that is designed for performance.
 
-In Chapter \@ref(debugging), we'll first talk about debugging, because finding the root cause of error can be extremely frustrating. Fortunately R has some great tools for debugging, and when they're coupled with a solid strategy, you should be able to find the root cause for most problems rapidly and relatively painlessly.
+1.  Chapter \@ref(debugging) talks about debugging, because finding the root cause of
+error can be extremely frustrating. Fortunately R has some great tools for debugging, and when they're coupled with a solid strategy, you should be able to find the root cause for most problems rapidly and relatively painlessly.
 
-The remaining three chapters focus on performance, first measuring it (Chapter \@ref(perf-measure)) and then improving it (Chapters \@ref(perf-improve) and \@ref(rcpp)). Tools to measure and improve performance are particularly important because R is not a fast language. This is not an accident: R was purposely designed to make interactive data analysis easier for humans, not to make computers as fast as possible. While R is slow compared to other programming languages, for most purposes, it's fast enough. These chapters help you handle the cases where R is no longer fast enough, either by improving the performance of your R code, or by switching to a language, C++, that is designed for performance.
+1.  Chapter \@ref(perf-measure) focuses on measuring performance. 
+
+1.  Chapter \@ref(perf-improve) then shows how to improve performance.
+

--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -998,7 +998,7 @@ There are two common uses of `NULL`:
 
 If you're familiar with SQL, you'll know about relational `NULL` and might expect it to be the same as R's. However, the database `NULL` is actually equivalent to R's `NA`.
 
-## Quiz Answers {#data-structure-answers}
+## Quiz answers {#data-structure-answers}
 
 1.  The four common types of atomic vector are logical, integer, double 
     and character. The two rarer types are complex and raw.

--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -446,9 +446,9 @@ grade <- ordered(c("b", "b", "a", "c"), levels = c("c", "b", "a"))
 grade
 ```
 
-In base R[^tidyverse-factors] you tend to encounter factors very frequently because many base R functions (like `read.csv()` and `data.frame()`) automatically convert character vectors to factors. This is suboptimal because there's no way for those functions to know the set of all possible levels or their correct order: the levels are a property of theory or experimental design, not of the data. Instead, use the argument `stringsAsFactors = FALSE` to suppress this behaviour, and then manually convert character vectors to factors using your knowledge of the "theoretical" data. To learn about the historical context of this behaviour, I recommend [*stringsAsFactors: An unauthorized
-biography*](http://simplystatistics.org/2015/07/24/stringsasfactors-an-unauthorized-biography/) by Roger Peng, and [*stringsAsFactors = 
-\<sigh\>*](http://notstatschat.tumblr.com/post/124987394001/stringsasfactors-sigh) by Thomas Lumley.
+In base R[^tidyverse-factors] you tend to encounter factors very frequently because many base R functions (like `read.csv()` and `data.frame()`) automatically convert character vectors to factors. This is suboptimal because there's no way for those functions to know the set of all possible levels or their correct order: the levels are a property of theory or experimental design, not of the data. Instead, use the argument `stringsAsFactors = FALSE` to suppress this behaviour, and then manually convert character vectors to factors using your knowledge of the "theoretical" data. To learn about the historical context of this behaviour, I recommend [_stringsAsFactors: An unauthorized
+biography_](http://simplystatistics.org/2015/07/24/stringsasfactors-an-unauthorized-biography/) by Roger Peng, and [_stringsAsFactors = 
+\<sigh\>_](http://notstatschat.tumblr.com/post/124987394001/stringsasfactors-sigh) by Thomas Lumley.
 
 [^tidyverse-factors]: The tidyverse never automatically coerces characters to factors, and provides the forcats [@forcats] package specifically for working with factors.
 
@@ -895,7 +895,7 @@ You can coerce an object to a data frame with `as.data.frame()` or to a tibble w
 \index{data frames!list-columns}
 \indexc{I()}
 
-Since a data frame is a list of vectors, it is possible for a data frame to have a column that is a list. This is very useful because a list can contain any other object: this means you can put any object in a data frame. This allows you to keep related objects together in a row, no matter how complex the individual objects are. You can see an application of this in the "Many Models" chapter of "R for Data Science", <http://r4ds.had.co.nz/many-models.html>.
+Since a data frame is a list of vectors, it is possible for a data frame to have a column that is a list. This is very useful because a list can contain any other object: this means you can put any object in a data frame. This allows you to keep related objects together in a row, no matter how complex the individual objects are. You can see an application of this in the "Many Models" chapter of _R for Data Science_, <http://r4ds.had.co.nz/many-models.html>.
 
 List-columns are allowed in data frames but you have to do a little extra work by either adding the list-column after creation or wrapping the list in `I()`[^identity].
 


### PR DESCRIPTION
This fixes some global problems. 

* It removes all quotemarks around blockquotes.

* Makes sure there are no "he or she" or "him or her".

* Removes capitalization in "Quiz **A**nswers".

* Rewrites chapter overviews so that they match in style. The OO part didn't have a chapter overview so I wrote one. I don't know exactly *where* it would go, though. 

I need to solve some issues but I need your input:

* Some tables have captions (Tables 19.1 and 19.2) but the rest don't. Should every table (and figure?) have a caption?
* When citing books and other resources sometimes they are around quotes (`...I found "Concepts, Techniques and Models of Computer Programming" [@ctmcp] extremely helpful.`) while others are italicised (`...the terminology of _Extending R_ [@extending-R] and call...`). Should they all be one way or the other? Which one? 