### PR TITLE
Fix typo: in_dir() -> with_dir()

### DIFF
--- a/Functions.Rmd
+++ b/Functions.Rmd
@@ -1033,7 +1033,7 @@ j09()
 
 1.  What does `write.table()` return? What would be more useful?
 
-1.  How does the `chdir` parameter of `source()` compare to `in_dir()`? Why 
+1.  How does the `chdir` parameter of `source()` compare to `with_dir()`? Why 
     might you prefer one to the other?
 
 1.  Write a function that opens a graphics device, runs the supplied code, and 


### PR DESCRIPTION
The example above defines `with_dir()`. Looks like the example used to define `in_dir()` and this question needs to be updated.