### PR TITLE
Update URL for Rcpp example

### DIFF
--- a/Rcpp.Rmd
+++ b/Rcpp.Rmd
@@ -943,7 +943,7 @@ bench::mark(
 
 <!-- FIXME: needs more context? -->
 
-This example is adapted from ["Rcpp is smoking fast for agent-based models in data frames"](https://gweissman.github.io/babelgraph/blog/2017/06/15/rcpp-is-smoking-fast-for-agent-based-models-in-data-frames.html). The challenge is to predict a model response from three inputs. The basic R version of the predictor looks like:
+This example is adapted from ["Rcpp is smoking fast for agent-based models in data frames"](https://gweissman.github.io/post/rcpp-is-smoking-fast-for-agent-based-models-in-data-frames/). The challenge is to predict a model response from three inputs. The basic R version of the predictor looks like:
 
 ```{r}
 vacc1a <- function(age, female, ily) {


### PR DESCRIPTION
Apologies for the URL change -- updated static github site to blogdown, will now be stable for the forseeable future. Thanks for the link.