### PR TITLE
Possible typo in Quiz answers

### DIFF
--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -1017,5 +1017,5 @@ If you're familiar with SQL, you'll know about relational `NULL` and might expec
     make a matrix a column of a data frame with `df$x <- matrix()`, or by
     using `I()` when creating a new data frame `data.frame(x = I(matrix()))`.
 
-1.  Tibbles have an enhanced print method, which never coerces strings to 
+1.  Tibbles have an enhanced print method, never coerce strings to 
     factors, and provide stricter subsetting methods.


### PR DESCRIPTION
The sentence previously read as if 'never coerces strings to factors' related to the print method for tibbles, whereas it should relate to tibbles more generally.

I assign the copyright of this contribution to Hadley Wickham.