### PR TITLE
Fix typo

### DIFF
--- a/Debugging.Rmd
+++ b/Debugging.Rmd
@@ -238,7 +238,7 @@ There are two other slightly less useful commands that aren't available in the t
 
 ### Alternatives
 
-There are three alternatives to using `browser()`: setting breakpoints in RStudio, `option(error = recover)`, and `debug()` and other related functions.
+There are three alternatives to using `browser()`: setting breakpoints in RStudio, `options(error = recover)`, and `debug()` and other related functions.
 
 #### Breakpoints
 \index{breakpoints}


### PR DESCRIPTION
`option()` -> `options()`

I assign the copyright of this contribution to Hadley Wickham.