### PR TITLE
Move inline more prominently into code

### DIFF
--- a/C-interface.Rmd
+++ b/C-interface.Rmd
@@ -1,7 +1,3 @@
-```{r, echo = FALSE, message = FALSE}
-library(inline)
-```
-
 # R's C interface {#c-api}
 
 Reading R's source code is an extremely powerful technique for improving your programming skills. However, many base R functions, and many functions in older packages, are written in C. It's useful to be able to figure out how those functions work, so this chapter will introduce you to R's C API. You'll need some basic C knowledge, which you can get from a standard C text (e.g., [_The C Programming Language_](http://amzn.com/0131101633?tag=devtools-20) by Kernigan and Ritchie), or from [Rcpp](#rcpp). You'll need a little patience, but it is possible to read R's C source code, and you will learn a lot doing it. \index{C}
@@ -76,7 +72,8 @@ add <- function(a, b) {
 
 In this chapter we'll produce the two pieces in one step by using the `inline` package. This allows us to write:  \indexc{cfunction()}
 
-```{r, cache = TRUE}
+```{r, cache = TRUE, message = FALSE}
+library(inline)
 add <- cfunction(c(a = "integer", b = "integer"), "
   SEXP result = PROTECT(allocVector(REALSXP, 1));
   REAL(result)[0] = asReal(a) + asReal(b);


### PR DESCRIPTION
A cursory read of the text as is had me scratching my head about where `cfunction` is coming from if not `pryr`.

Closer read found the Prerequisites section, which mentions both `pryr` and `inline`. So it's a bit odd that `library(pryr)` is surfaced but `library(inline)` is not.

So, surfacing it here for future readers like me :)