### PR TITLE
Typo, deleting unnecessary "to"

### DIFF
--- a/Big-picture.Rmd
+++ b/Big-picture.Rmd
@@ -180,7 +180,7 @@ eval(expr(x + y))
 One of the big advantages of evaluating code manually is that you can tweak the environment. There are two main reasons to do this:
 
 * To temporarily override functions to implement a domain specific language.
-* To add a data mask so you can to refer to variables in a data frame as if
+* To add a data mask so you can refer to variables in a data frame as if
   they are variables in an environment.
 
 ## Customising evaluation with functions {#eval-funs}


### PR DESCRIPTION
 "I assign the copyright of this contribution to Hadley Wickham".