### PR TITLE
Use `selectMethod` instead of `getMethod`

### DIFF
--- a/Perf-improve.Rmd
+++ b/Perf-improve.Rmd
@@ -172,7 +172,7 @@ Sometimes you can make a function faster by avoiding method dispatch. If you're 
 
 * For S3, you can do this by calling `generic.class()` instead of `generic()`. 
 
-* For S4, you can do this by using `getMethod()` to find the method, saving 
+* For S4, you can do this by using `selectMethod()` to find the method, saving 
   it to a variable, and then calling that function. 
 
 For example, calling `mean.default()` is quite a bit faster than calling `mean()` for small vectors:


### PR DESCRIPTION
`selectMethod` should be recommended since `getMethod` does not handle inheritance.