### PR TITLE
Typo in quasiquotation

### DIFF
--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -910,7 +910,7 @@ data.frame(
   no missing arguments.
 
 * `.homonoyms` controls what happens if multiple arguments use the same name:
-
+* `.homonyms` controls what happens if multiple arguments use the same name:
     ```{r, error = TRUE}
     str(dots_list(x = 1, x = 2))
     str(dots_list(x = 1, x = 2, .homonyms = "first"))


### PR DESCRIPTION
Line 912 - "homonoyms" to "homonyms". Thanks.