### PR TITLE
Small error in example, Section 20.3.2

### DIFF
--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -281,14 +281,14 @@ There are three ways to create quosures:
 \index{quosures!evaluating}
 \indexc{eval\_tidy()}
 
-Quosures are paired with a new evaluation function `eval_tidy()` that takes a single quosure instead of a expression-environment pair. It is straightforward to use:
+Quosures are paired with a new evaluation function `eval_tidy()` that takes a single quosure instead of an expression-environment pair. It is straightforward to use:
 
 ```{r}
 q1 <- new_quosure(expr(x + y), env(x = 1, y = 10))
 eval_tidy(q1)
 ```
 
-For this simple case, `eval_tidy(q1)` is basically a shortcut for `eval(get_expr(q1), get_env(q2))`. However, it has two important features that you'll learn about later in the chapter: it supports nested quosures (Section \@ref(nested-quosures)) and pronouns (Section \@ref(pronouns)).
+For this simple case, `eval_tidy(q1)` is basically a shortcut for `eval(get_expr(q1), get_env(q1))`. However, it has two important features that you'll learn about later in the chapter: it supports nested quosures (Section \@ref(nested-quosures)) and pronouns (Section \@ref(pronouns)).
 
 ### Dots {#quosure-dots}
 \indexc{...}


### PR DESCRIPTION
Based on the code in this section, doesn't it make sense to write `eval(get_expr(q1), get_env(q1))` rather than `eval(get_expr(q1), get_env(q2))`? Also corrected a little typo in the same section.