### PR TITLE
Fix typo in Promises

### DIFF
--- a/Functions.Rmd
+++ b/Functions.Rmd
@@ -582,7 +582,7 @@ A promise has three components:
       c(x, x)
     }
     
-    h03(double(x))
+    h03(double(20))
     ```
 
 You cannot manipulate promises with R code. Promises are like a quantum state: any attempt to inspect them with R code will force an immediate evaluation, making the promise disappear. Later, in Section \@ref(quosures), you'll learn about quosures, which convert promises into an R object where you can easily inspect the expression and the environment.


### PR DESCRIPTION
This works because you defined `x <- 20` on line 473, but it doesn't make any sense in the context of the discussion of promises.