### PR TITLE
update `x` when describing `unname()`

### DIFF
--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -81,7 +81,6 @@ knitr::include_graphics("diagrams/vectors/summary-tree-atomic.png")
 
 ### Scalars
 \index{scalars}
-\indexc{NaN}
 \indexc{Inf} 
 \indexc{L}
 \indexc{""}
@@ -304,7 +303,7 @@ names(x) <- c("a", "b", "c")
 x <- setNames(1:3, c("a", "b", "c"))
 ```
 
-Avoid using `attr(x, "names")` as it requires more typing and is less readable than `names(x)`. You can remove names from a vector by using `unname(x)` or `names(x) <- NULL`. 
+Avoid using `attr(x, "names")` as it requires more typing and is less readable than `names(x)`. You can remove names from a vector by using `x <- unname(x)` or `names(x) <- NULL`. 
 
 To be technically correct, when drawing the named vector `x`, I should draw it like so:
 


### PR DESCRIPTION
The two ways to remove names from `x` are different:

- `unname()` prints the result, but does not update `x` 
- `names(x) <- NULL` updates `x` 

The text of "you can remove names from a vector" may be interpreted by the reader to believe `x` is updated. This proposal explicitly updates `x`.