### PR TITLE
consistent approaches to removing vector names

### DIFF
--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -304,7 +304,7 @@ names(x) <- c("a", "b", "c")
 x <- setNames(1:3, c("a", "b", "c"))
 ```
 
-Avoid using `attr(x, "names")` as it requires more typing and is less readable than `names(x)`. You can remove names from a vector by using `unname(x)` or `names(x) <- NULL`. 
+Avoid using `attr(x, "names")` as it requires more typing and is less readable than `names(x)`. You can remove names from a vector by using `x <- unname(x)` or `names(x) <- NULL`. 
 
 To be technically correct, when drawing the named vector `x`, I should draw it like so:
 


### PR DESCRIPTION
Currently, the two ways described to remove names from a vector are different:

- `unname()` prints the result, but does not update `x`
- `names(x) <- NULL` updates `x`

A reader may interpret the preceding text "you can remove names from a vector" as `x` being updated. This proposal change explicitly updates `x`.