### PR TITLE
make `is` example clearer

### DIFF
--- a/S4.Rmd
+++ b/S4.Rmd
@@ -216,7 +216,7 @@ is(new("Employee"))
 To test if an object inherits from a specific class, use the second argument of `is()`:
 
 ```{r}
-is(john, "person")
+is(john, "Person")
 ```
 
 ### Redefinition


### PR DESCRIPTION
I think this is a typo, the `is` example returns FALSE because the capitalization of the class name is wrong.

``` r
library(methods)

setClass("Person", 
         slots = c(
           name = "character", 
           age = "numeric"
         ), 
         prototype = list(
           name = NA_character_,
           age = NA_real_
         )
)

john <- new("Person", name = "John Smith", age = NA_real_)

# Old:
is(john, "person")
#> [1] FALSE

# After PR:
is(john, "Person")
#> [1] TRUE
```

<sup>Created on 2020-01-07 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>