### PR TITLE
Back-ref to attributes for pairlists

### DIFF
--- a/Expressions.Rmd
+++ b/Expressions.Rmd
@@ -897,10 +897,10 @@ args
 typeof(args)
 ```
 
-2. when working with attributes[^pairlist-attr]
+1. when working with attributes[^pairlist-attr]
 
 [^pairlists-c]: If you're working in C, you'll encounter pairlists more often. For example, call objects are also implemented using pairlists.
-[pairlist-attr]: see \@ref(attributes).
+[^pairlist-attr]: see \@ref(attributes).
 
 Fortunately, whenever you encounter a pairlist, you can treat it just like a regular list:
 

--- a/Expressions.Rmd
+++ b/Expressions.Rmd
@@ -885,7 +885,9 @@ There are two data structures and one special symbol that we need to cover for t
 ### Pairlists
 \index{pairlists}
 
-Pairlists are a remnant of R's past and have been replaced by lists almost everywhere. The only place you are likely to see pairlists in R[^pairlists-c] is when working with calls to the `function` function, as the formal arguments to a function are stored in a pairlist:
+Pairlists are a remnant of R's past and have been replaced by lists almost everywhere. There are only two places you are likely to see pairlists in R[^pairlists-c].
+
+1. when working with calls to the `function` function, as the formal arguments to a function are stored in a pairlist:
 
 ```{r}
 f <- expr(function(x, y = 10) x + y)
@@ -895,7 +897,10 @@ args
 typeof(args)
 ```
 
+2. when working with attributes[^pairlist-attr]
+
 [^pairlists-c]: If you're working in C, you'll encounter pairlists more often. For example, call objects are also implemented using pairlists.
+[pairlist-attr]: see \@ref(attributes).
 
 Fortunately, whenever you encounter a pairlist, you can treat it just like a regular list:
 


### PR DESCRIPTION
In section 3.2.1 the first note (16) points to this chapter to explore pairlists when referred to attributes. What about explain that case too, and the reason why they are not lists (or what are the advantages or the limitations)?

I don’t know if/how you would like to expand this chapter; the purposed changes are only to back ref to the chapter which pointed here.