### PR TITLE
Update Subsetting.Rmd

### DIFF
--- a/Subsetting.Rmd
+++ b/Subsetting.Rmd
@@ -267,7 +267,7 @@ str(df[, "x"])
 
 By default, subsetting a matrix or data frame with a single number, a single name, or a logical vector containing a single `TRUE`, will simplify the returned output, i.e. it will return an object with lower dimensionality. To preserve the original dimensionality, you must use `drop = FALSE`.
 
-*   For matrices and arrays, any dimensions with length 1 will be dropped:
+*   When subsetting matrices and arrays, any dimensions with length 1 will be dropped:
     
     ```{r}
     a <- matrix(1:4, nrow = 2)
@@ -276,7 +276,7 @@ By default, subsetting a matrix or data frame with a single number, a single nam
     str(a[1, , drop = FALSE])
     ```
 
-*   Data frames with a single column will return just that column:
+*   Subset data frames with a single column will return just that column:
 
     ```{r}
     df <- data.frame(a = 1:2, b = 1:2)


### PR DESCRIPTION
Those are true only when subset is performed: a data frame with a single column is (and return) a data frame, as arrays with some dimension with length one don’t drop them.

```
matrix(1:4, nrow = 1)
data.frame(x = 1:4)
```