### PR TITLE
Fix typo: less -> more

### DIFF
--- a/Control-flow.Rmd
+++ b/Control-flow.Rmd
@@ -343,7 +343,7 @@ R does not have an equivalent to the `do {action} while (condition)` syntax foun
 
 You can rewrite any `for` loop to use `while` instead, and you can rewrite any `while` loop to use `repeat`, but the converses are not true. That means `while` is more flexible than `for`, and `repeat` is more flexible than `while`. It's good practice, however, to use the least-flexible solution to a problem, so you should use `for` wherever possible.
 
-Generally speaking you shouldn't need to use `for` loops for data analysis tasks, as `map()` and `apply()` already provide less flexible solutions to most problems. You'll learn more in Chapter \@ref(functionals).
+Generally speaking you shouldn't need to use `for` loops for data analysis tasks, as `map()` and `apply()` already provide more flexible solutions to most problems. You'll learn more in Chapter \@ref(functionals).
 
 ### Exercises
 


### PR DESCRIPTION
Near the end of the control flow chapter, I think the intention was to say *more* instead of *less*