### PR TITLE
Change output vector initialization

### DIFF
--- a/Functionals.Rmd
+++ b/Functionals.Rmd
@@ -579,7 +579,7 @@ The basic implementation of `map2()` is simple, and quite similar to that of `ma
 
 ```{r}
 simple_map2 <- function(x, y, f, ...) {
-  out <- vector("list", length(xs))
+  out <- vector("list", length(x))
   for (i in seq_along(x)) {
     out[[i]] <- f(x[[i]], y[[i]], ...)
   }


### PR DESCRIPTION
`simple_map2` works for the xs and ws provided, but using `xs` to set the length of the output vector could cause some unexpected behavior (e.g., 5 `NULL`s in the output vector if making `xs` and `ws` length-3 vectors).