### PR TITLE
Python naming convention is `self`, not `this`

### DIFF
--- a/R6.Rmd
+++ b/R6.Rmd
@@ -71,7 +71,7 @@ The following example shows the two most important arguments to `R6Class()`:
   the methods and fields of the current object via `self$`.[^python]
   \index{methods!R6}
 
-[^python]: Unlike in `this` in python, the `self` variable is automatically provided by R6, and does not form part of the method signature.
+[^python]: Unlike in Python, the `self` variable is automatically provided by R6, and does not form part of the method signature.
 
 ```{r}
 Accumulator <- R6Class("Accumulator", list(


### PR DESCRIPTION
Python naming convention for the reference to the object itself is `self`, not `this`.