### PR TITLE
Added an example where a warning should definitely be an error

### DIFF
--- a/Conditions.Rmd
+++ b/Conditions.Rmd
@@ -182,6 +182,8 @@ formals(1)
 file.remove("this-file-doesn't-exist")
 
 lag(1:3, k = 1.5)
+
+as.numeric (c("18", "30", "50+", "345,678"))
 ```
 
 There are only a couple of cases where using a warning is clearly appropriate:

--- a/Conditions.Rmd
+++ b/Conditions.Rmd
@@ -183,7 +183,7 @@ file.remove("this-file-doesn't-exist")
 
 lag(1:3, k = 1.5)
 
-as.numeric (c("18", "30", "50+", "345,678"))
+as.numeric(c("18", "30", "50+", "345,678"))
 ```
 
 There are only a couple of cases where using a warning is clearly appropriate:


### PR DESCRIPTION
We are prone to hurriedly converting variables that "look like" numerical data into numeric, without thoroughly investigating to check whether there are some "illegal" characters that exist e.g. commas, "+", hyphens, etc. These leads to NAs which should have been avoided in the first place. We are often prone to ignoring warnings, but this is an "error" that should never be ignored. 
![image](https://user-images.githubusercontent.com/37449624/93312136-83f08f80-f80f-11ea-8cf3-00cb666c2376.png)
