### PR TITLE
Is "unique names" enough?

### DIFF
--- a/Environments.Rmd
+++ b/Environments.Rmd
@@ -61,7 +61,7 @@ The `env_` functions in rlang are designed to work with the pipe: all take an en
 
 Generally, an environment is similar to a named list, with four important exceptions:
 
-*   Every name must be unique.
+*   Every name must be unique and all of its objects be binded to a name.
 
 *   The names in an environment are not ordered.
 


### PR DESCRIPTION
In a list you can have objects that are not named, but in environment you cannot as you say latter in the Quiz Answer as "every object in an environment must have a name". As a non native speaker I may be wrong, but saying "Every name must be unique", only imply that you cannot have two objects with the same name, not that you cannot have a object without names. 

So, in my understanding, saying in section 7.2 that  "Every name must be unique" cannot be easily translated to "every object in an environment must have a name". Therefore I think that adding "and all of its objects must  be binded to a name" serves it well.

This is undirectly explained through basics, but I think that changing that sentence prepares more the reader to the following of the chapter.

Thanks for your time!