### PR TITLE
Tighten `chatty()` example

### DIFF
--- a/Function-operators.Rmd
+++ b/Function-operators.Rmd
@@ -14,9 +14,8 @@ chatty <- function(f) {
   force(f)
   
   function(x, ...) {
-    res <- f(x, ...)
-    cat("Processing ", x, "\n", sep = "")
-    res
+    message("Processing ", x)
+    f(x, ...)
   }
 }
 f <- function(x) x ^ 2


### PR DESCRIPTION
I may be missing a deeper point here, but it seems simpler for `chatty()` to use `message()` instead of `cat()` and call it before the processing begins?