### PR TITLE
Update redirect from 1st edition to 2nd edition

### DIFF
--- a/index.rmd
+++ b/index.rmd
@@ -4,7 +4,7 @@ title: Welcome
 ---
 
 <div class="alert alert-info">
-You're reading the first edition of Advanced R; for the latest version see the <a href = "http://adv-r.had.co.nz/Introduction.html" class="alert-link">second edition</a>.</div>
+You're reading the first edition of Advanced R; for the latest version see the <a href = "https://adv-r.hadley.nz" class="alert-link">second edition</a>.</div>
 
 # Welcome
 


### PR DESCRIPTION
The link on the first edition page was pointing back to the first edition. I updated the link to point to the second edition.