### PR TITLE
Minor typo (a vs. an) OO.Rmd

### DIFF
--- a/OO.Rmd
+++ b/OO.Rmd
@@ -55,7 +55,7 @@ The goal of this brief introductory chapter is to give you some important vocabu
 1.  Chapter \@ref(s3) introduces S3, the simplest and most commonly used
     OO system.
   
-1.  Chapter \@ref(r6) discusses R6, a encapsulated OO system built on 
+1.  Chapter \@ref(r6) discusses R6, an encapsulated OO system built on 
     top of environments.
 
 1.  Chapter \@ref(s4) introduces S4, which is similar to S3 but more formal and 


### PR DESCRIPTION
There was a tiny typo in line 58 (`an encapsulated` was written `a encapsulated`).