### PR TITLE
Typo fix in 14.3.1

### DIFF
--- a/R6.Rmd
+++ b/R6.Rmd
@@ -346,7 +346,7 @@ hadley3
 hadley3$name
 ```
 
-The distinction between public and private fields is important when you create complex networks of classes, and you want to make it as clear as possible what it's ok for others to access. Anything that's private can be more easily refactored because you know others aren't relying on it. Private methods tend to be less important in R compared to other programming languages because the object hierarchies in R tend to be simpler.
+The distinction between public and private fields is important when you create complex networks of classes, and you want to make it as clear as possible what is ok for others to access. Anything that's private can be more easily refactored because you know others aren't relying on it. Private methods tend to be less important in R compared to other programming languages because the object hierarchies in R tend to be simpler.
 
 ### Active fields
 \index{R6!active fields}


### PR DESCRIPTION
In the paragraph prior to 14.3.2 Active fields, this edit would replace "[what] it's [ok]" with "[what] is [ok]" in the following sentence: "The distinction between public and private fields is important when you create complex networks of classes, and you want to make it as clear as possible what is ok for others to access."