### PR TITLE
Update Vectors.Rmd to avoid object names overwriting base functions

### DIFF
--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -331,17 +331,17 @@ You can create matrices and arrays with `matrix()` and `array()`, or by using th
 
 ```{r}
 # Two scalar arguments specify row and column sizes
-a <- matrix(1:6, nrow = 2, ncol = 3)
-a
+x <- matrix(1:6, nrow = 2, ncol = 3)
+x
 
 # One vector argument to describe all dimensions
-b <- array(1:12, c(2, 3, 2))
-b
+y <- array(1:12, c(2, 3, 2))
+y
 
 # You can also modify an object in place by setting dim()
-c <- 1:6
-dim(c) <- c(3, 2)
-c
+z <- 1:6
+dim(z) <- c(3, 2)
+z
 ```
 
 Many of the functions for working with vectors have generalisations for matrices and arrays:


### PR DESCRIPTION
Changed the example object names in the first chunk in https://adv-r.hadley.nz/vectors-chap.html#attr-dims, in order to avoid giving a function name to an object `c <- ...` I renamed all the examples in the chunk from a, b, c to x, y, z.