### PR TITLE
Update Vectors.Rmd removing stringAsFactors

### DIFF
--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -702,17 +702,6 @@ df <- data.frame(
 str(df)
 ```
 
-Beware of the default conversion of strings to factors. Use `stringsAsFactors = FALSE` to suppress this and keep character vectors as character vectors:
-
-```{r}
-df1 <- data.frame(
-  x = 1:3,
-  y = c("a", "b", "c"),
-  stringsAsFactors = FALSE
-)
-str(df1)
-```
-
 Creating a tibble is similar to creating a data frame. The difference between the two is that tibbles never coerce their input (this is one feature that makes them lazy):
 
 ```{r}


### PR DESCRIPTION
Since version 4.0.0 R uses a stringsAsFactors = FALSE default. Both data.frame creations have the same result now.