### PR TITLE
Fix typo in Factories exercise: model --> formula

### DIFF
--- a/Function-factories.Rmd
+++ b/Function-factories.Rmd
@@ -689,7 +689,7 @@ These advantages get bigger in more complex MLE problems, where you have multipl
 ### Exercises
 
 1.  In `boot_model()`, why don't I need to force the evaluation of `df` 
-    or `model`?
+    or `formula`?
     
 1.  Why might you formulate the Box-Cox transformation like this?
 


### PR DESCRIPTION
The `boot_model()` function does not have a `model` argument. It does have `formula`.

https://github.com/hadley/adv-r/blob/1ab83672ad077400b842938804a3773f4279115c/Function-factories.Rmd#L554-L563
