### PR TITLE
Removed unnecessary class 'sidebar'

### DIFF
--- a/Names-values.Rmd
+++ b/Names-values.Rmd
@@ -161,9 +161,7 @@ It's possible to override these rules and use any name, i.e., any sequence of ch
 
 While it's unlikely you'd deliberately create such crazy names, you need to understand how these crazy names work because you'll come across them, most commonly when you load data that has been created outside of R.
 
-::: sidebar
 You _can_ also create non-syntactic bindings using single or double quotes (e.g. `"_abc" <- 1`) instead of backticks, but you shouldn't, because you'll have to use a different syntax to retrieve the values. The ability to use strings on the left hand side of the assignment arrow is an historical artefact, used before R supported backticks.
-:::
 
 ### Exercises
 


### PR DESCRIPTION
In the main content there is part of the text wrapped inside a `sidebar` class, which sets max width, if > 1200px. I don't know if this class is important for the book export as PDF but at least for the browser version it does make no difference if we remove it.

If it is important for the PDF export, it would make sense to write a css exception for `sidebar` inside `content` class.

![sidebar class content](https://user-images.githubusercontent.com/16878981/107529332-0dd43700-6bbb-11eb-9be5-c4f1381895c8.png)

I assign the copyright of this contribution to Hadley Wickham.

Cheers
Hannes