### PR TITLE
Refine void_tag() description

### DIFF
--- a/Translation.Rmd
+++ b/Translation.Rmd
@@ -246,7 +246,7 @@ i <- tag("i")
 p("Some text. ", b(i("some bold italic text")), class = "mypara")
 ```
 
-Before we generate functions for every possible HTML tag, we need to create a variant that handles void tags. `void_tag()` is quite similar to `tag()`, but it throws an error if there are any unnamed tags, and the tag itself looks a little different.
+Before we generate functions for every possible HTML tag, we need to create a variant that handles void tags. `void_tag()` is quite similar to `tag()`, but it throws an error if there are any child tags, as captured by the unnamed dots. The tag itself also looks a little different.
 
 ```{r}
 void_tag <- function(tag) {


### PR DESCRIPTION
Slight change of language to say that functions generated by `void_tag()` error when given "child tags", rather than "unnamed tags" and that those child tags are captured by "unnamed dots".

I assign the copyright of this contribution to Hadley Wickham.