### PR TITLE
Replace paste0 with paste in Control-flow.Rmd

### DIFF
--- a/Control-flow.Rmd
+++ b/Control-flow.Rmd
@@ -77,9 +77,9 @@ When you use the single argument form without an else statement, `if` invisibly 
 
 ```{r}
 greet <- function(name, birthday = FALSE) {
-  paste0(
-    "Hi ", name,
-    if (birthday) " and HAPPY BIRTHDAY"
+  paste(
+    "Hi", name,
+    if (birthday) "and HAPPY BIRTHDAY"
   )
 }
 greet("Maria", FALSE)


### PR DESCRIPTION
Hello! I think `paste0()` is being misused in the birthday example. `paste0` is literally `paste()` with `sep=""`; why use it and then manually put blanket spaces at the strings?  I know it is a silly "correction", but this section of the book is all about the little details, tricks and optimizations that can make your code cleaner and more efficient. I think this example is going against that philosophy; kinda like using `x[which(y)]` instead of `x[y],` as you describe in chapter 4. (Btw I think that `paste0()` is the ugliest function name in all R and prefer to use `paste(sep="")`, just to make the code nicer :) ).

Have all a nice day!