### PR TITLE
Taking out sidebar

### DIFF
--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -147,7 +147,6 @@ source2 <- function(path, env = caller_env()) {
 The real `source()` is considerably more complicated because it can `echo` input and output, and has many other settings that control its behaviour.
 
 
-::: sidebar
 **Expression vectors**
 \index{expression vectors}
 
@@ -162,7 +161,7 @@ source3 <- function(file, env = parent.frame()) {
 ```
 
 While `source3()` is considerably more concise than `source2()`, this is the only advantage to expression vectors. Overall I don't believe this benefit outweighs the cost of introducing a new data structure, and hence this book avoids the use of expression vectors.
-:::
+
 
 
 ### Gotcha: `function()`


### PR DESCRIPTION
In the part about Expression Vectors of section 20.2.2, the formatting restricts lines to less than half the page, being unfriendly to the readers.

In the PC it displays as bellow (zoom 50% less):

![advR_bad_format](https://user-images.githubusercontent.com/46865047/112333020-fea3d700-8c98-11eb-940c-8f2e4a166e93.png)
