### PR TITLE
Update Quotation.Rmd -- typo in `purr::reduce()`

### DIFF
--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -1020,7 +1020,7 @@ lobstr::ast(!!z)
 
 ### Map-reduce to generate code
 
-Quasiquotation gives us powerful tools for generating code, particularly when combined with `purrr::map()` and `purr::reduce()`. For example, assume you have a linear model specified by the following coefficients:
+Quasiquotation gives us powerful tools for generating code, particularly when combined with `purrr::map()` and `purrr::reduce()`. For example, assume you have a linear model specified by the following coefficients:
 
 ```{r}
 intercept <- 10


### PR DESCRIPTION
Typo: `purr::reduce()` is missing an "r".