### PR TITLE
Update Perf-improve.Rmd - error in comparing the variations of computing the mean

### DIFF
--- a/Perf-improve.Rmd
+++ b/Perf-improve.Rmd
@@ -87,7 +87,7 @@ bench::mark(
 )[c("expression", "min", "median", "itr/sec", "n_gc")]
 ```
 
-(You might be surprised by the results: `mean(x)` is considerably slower than `sum(x) / length(x)`. This is because, among other reasons, `mean(x)` makes two passes over the vector to be more numerically accurate.)
+As we can see, `mean(x)` is faster than `sum(x) / length(x)`.
 
 If you'd like to see this strategy in action, I've used it a few times on stackoverflow:
 


### PR DESCRIPTION
Prose claims mean(x) is considerably slower than sum(x) / length(x). However, microbenchmark output shows that mean(x) is faster than sum(x) / length(x). Output included below. 

mean1 <- function(x) mean(x)
mean2 <- function(x) sum(x) / length(x)

x <- runif(1e5)

bench::mark(
  mean1(x),
  mean2(x)
)[c("expression", "min", "median", "itr/sec", "n_gc")]
#> # A tibble: 2 x 4
#>   expression      min   median `itr/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl>
#> 1 mean1(x)      162µs    176µs     5571.
#> 2 mean2(x)      190µs    202µs     4914.

I assign the copyright of this contribution to Hadley Wickham.