### PR TITLE
Update Function-operators.Rmd - Typo

### DIFF
--- a/Function-operators.Rmd
+++ b/Function-operators.Rmd
@@ -232,7 +232,7 @@ Think carefully before memoising a function. If the function is not __pure__, i.
 ## Case study: Creating your own function operators {#fo-case-study}
 \index{loops}
 
-`meomoise()` and `safely()` are very useful but also quite complex. In this case study you'll learn how to create your own simpler function operators. Imagine you have a named vector of URLs and you'd like to download each one to disk. That's pretty simple with `walk2()` and `file.download()`:
+`meomoise()` and `safely()` are very useful but also quite complex. In this case study you'll learn how to create your own simpler function operators. Imagine you have a named vector of URLs and you'd like to download each one to disk. That's pretty simple with `walk2()` and `download.file()`:
 
 ```{r}
 urls <- c(


### PR DESCRIPTION
`file.download()` should be corrected to `download.file()`

Fixes https://github.com/hadley/adv-r/issues/1686

I assign the copyright of this contribution to Hadley Wickham.

Cheers
Hannes

