### PR TITLE
Update Function-operators.Rmd - Typo

### DIFF
--- a/Function-operators.Rmd
+++ b/Function-operators.Rmd
@@ -332,7 +332,7 @@ The pipe works well here because I've carefully chosen the function names to yie
     `download.file %>% dot_every(10) %>% delay_by(0.1)` versus
     `download.file %>% delay_by(0.1) %>% dot_every(10)`.
     
-1.  Should you memoise `file.download()`? Why or why not?
+1.  Should you memoise `download.file()`? Why or why not?
 
 1.  Create a function operator that reports whenever a file is created or 
     deleted in the working directory, using `dir()` and `setdiff()`. What other 


### PR DESCRIPTION
Same typo as in https://github.com/hadley/adv-r/pull/1688

`file.download()` should be corrected to `download.file()`

I assign the copyright of this contribution to Hadley Wickham.

Cheers
Hannes
