### PR TITLE
Update Rcpp.Rmd - Overwrite wrong auto-links to R Functions

### DIFF
--- a/Rcpp.Rmd
+++ b/Rcpp.Rmd
@@ -859,7 +859,7 @@ To practice using the STL algorithms and data structures, implement the followin
 
 1. `median.default()` using `partial_sort`.
 
-1. `%in%` using `unordered_set` and the `find()` or `count()` methods.
+1. `%in%` using `unordered_set` and the [`find()`](https://en.cppreference.com/w/cpp/container/unordered_set/find) or [`count()`](https://en.cppreference.com/w/cpp/container/unordered_set/count) methods.
 
 1. `unique()` using an `unordered_set` (challenge: do it in one line!).
 


### PR DESCRIPTION
The `find()` and `count()` function was linking to the R function definition, it should in this case link to the corresponding C++ unordered set methods.

I assign the copyright of this contribution to Hadley Wickham.
