### PR TITLE
stringsAsFactors defaults to FALSE as of R 4.0.0

### DIFF
--- a/Vectors.Rmd
+++ b/Vectors.Rmd
@@ -702,7 +702,7 @@ df <- data.frame(
 str(df)
 ```
 
-Beware of the default conversion of strings to factors. Use `stringsAsFactors = FALSE` to suppress this and keep character vectors as character vectors:
+If you are using a version of R before 4.0.0, beware of the default conversion of strings to factors. Use `stringsAsFactors = FALSE` to suppress this and keep character vectors as character vectors:
 
 ```{r}
 df1 <- data.frame(


### PR DESCRIPTION
Under #df-create, the first example doesn't show the character column as a factor, presumably because this was written under R < 4.0.0 but now run under R >= 4.0.0.

"I assign the copyright of this contribution to Hadley Wickham"