### PR TITLE
Fix link to functions chapter in second edition

### DIFF
--- a/Functions.rmd
+++ b/Functions.rmd
@@ -5,7 +5,7 @@ output: oldbookdown::html_chapter
 ---
 
 <div class="alert alert-info">
-You're reading the first edition of Advanced R; for the latest on this topic, see the <a href = "https://style.tidyverse.org/functions.html" class="alert-link">Functions chapter</a> in the second edition.</div>
+You're reading the first edition of Advanced R; for the latest on this topic, see the <a href = "https://r4ds.had.co.nz/functions.html" class="alert-link">Functions chapter</a> in the second edition.</div>
 
 ```{r include=FALSE}
 knitr::opts_chunk$set(


### PR DESCRIPTION
This was by mistake pointing to the style guide.