### PR TITLE
Update Perf-measure.Rmd - profvis torture flag

### DIFF
--- a/Perf-measure.Rmd
+++ b/Perf-measure.Rmd
@@ -188,7 +188,7 @@ There are some other limitations to profiling:
 
 <!-- The explanation of `torture = TRUE` was removed in https://github.com/hadley/adv-r/commit/ea63f1e48fb523c013fb3df1860b7e0c227e1512 -->
 
-1.  Profile the following function with `torture = TRUE`. What is 
+1.  Profile the following function with `torture = 10`. What is 
     surprising? Read the source code of `rm()` to figure out what's going on.
 
     ```{r}


### PR DESCRIPTION
For me the exercise was not working as the GC was called too often? It is maybe only because my computer is too slow? Therefore I changed the torture to a higher integer than TRUE (1).

The torture flag takes an integer `profvis::profvis(torture = step)`  as in the background it uses `base::gctorture2` 

https://github.com/rstudio/profvis/blob/master/R/profvis.R
https://stat.ethz.ch/R-manual/R-devel/library/base/html/gctorture.html

Result from the exercise, with `torture=10`.

![profvis exersice](https://user-images.githubusercontent.com/16878981/130030623-42356e57-0856-4e1d-bc10-8251858d7dbf.png)

I assign the copyright of this contribution to Hadley Wickham.

