### PR TITLE
Removes sidebar format

### DIFF
--- a/Names-values.Rmd
+++ b/Names-values.Rmd
@@ -161,9 +161,8 @@ It's possible to override these rules and use any name, i.e., any sequence of ch
 
 While it's unlikely you'd deliberately create such crazy names, you need to understand how these crazy names work because you'll come across them, most commonly when you load data that has been created outside of R.
 
-::: sidebar
 You _can_ also create non-syntactic bindings using single or double quotes (e.g. `"_abc" <- 1`) instead of backticks, but you shouldn't, because you'll have to use a different syntax to retrieve the values. The ability to use strings on the left hand side of the assignment arrow is an historical artefact, used before R supported backticks.
-:::
+
 
 ### Exercises
 


### PR DESCRIPTION
This paragraph was strangely formatted. No need for the sidebar format according to me.

"I assign the copyright of this contribution to Hadley Wickham"