### PR TITLE
Typo

### DIFF
--- a/Functionals.Rmd
+++ b/Functionals.Rmd
@@ -284,11 +284,11 @@ In the diagrams, I've omitted argument names to focus on the overall structure. 
 This is the reason why the arguments to `map()` are a little odd: instead of being `x` and `f`, they are `.x` and `.f`. It's easiest to see the problem that leads to these names using `simple_map()` defined above. `simple_map()` has arguments `x` and `f` so you'll have problems whenever the function you are calling has arguments `x` or `f`:
 
 ```{r, error = TRUE}
-boostrap_summary <- function(x, f) {
+bootstrap_summary <- function(x, f) {
   f(sample(x, replace = TRUE))
 }
 
-simple_map(mtcars, boostrap_summary, f = mean)
+simple_map(mtcars, bootstrap_summary, f = mean)
 ```
 
 <!-- GVW: a diagram here showing how the various f's and x's are matched to one another in the example above would be very helpful -->


### PR DESCRIPTION
The assumingly correct argument name `bootstrap_summary` (notice `boot`, not `boo`) occurs inline just below this code chunk (line 296). 