### PR TITLE
Informing about the operator `:::`

### DIFF
--- a/S3.Rmd
+++ b/S3.Rmd
@@ -122,6 +122,12 @@ weighted.mean.Date
 
 s3_get_method(weighted.mean.Date)
 ```
+\index{S3!finding source}
+Equivalently, using the operators available in the base R, we could use the triple colon operator `:::` to access the unexported methods that live inside a package:
+
+```{r}
+stats:::weighted.mean.Date
+```
 
 [^base-s3]: The exceptions are methods found in the base package, like `t.data.frame`, and methods that you've created.
 


### PR DESCRIPTION
I think it would be good, in this section, to inform the role of the `:::` operator. The operator is used more explicitly in Section 10.3.3. Informing in the Section where the S3 object-oriented system is discussed would, in my opinion, be a good opportunity to make clear to the reader the usefulness of the `:::` operator.

Best regards.