### PR TITLE
Logical inconsistency between class and method

### DIFF
--- a/S3.Rmd
+++ b/S3.Rmd
@@ -105,8 +105,7 @@ s3_dispatch(print(f))
 ```
 
 \index{S3!methods}
-We'll come back to the details of dispatch in Section \@ref(method-dispatch), for now note that S3 methods are functions with a special naming scheme, `generic.class()`. For example, the `factor` method for the `print()` generic is called `print.factor()`. You should never call the method directly, but instead rely on the generic to find it for you.
-
+We'll get back to dispatch details in Section \@ref(method-dispatch), for now note that S3 methods are functions with a special naming scheme, `generic.class()`. For example, the appropriate method for working with an object of class `factor` and which is dispatched by the generic `print()` is `print.factor()`. You should never call the method directly, but rely on the generic to find it for you.
 Generally, you can identify a method by the presence of `.` in the function name, but there are a number of important functions in base R that were written before S3, and hence use `.` to join words. If you're unsure, check with `sloop::ftype()`:
 
 ```{r}


### PR DESCRIPTION
For a first-time reader of R S3 system concepts, it goes without saying that `factor` is a method. It's actually the class. In the context of factors, for which the text is intended to explain sending the `print.factor` method, there are only two methods in question:

1 - `print` which is the generic function to which we must entrust the sending of the appropriate method based, normally, on the class of the first argument;
2 - `print.factor` which will be the appropriate method dispatched by the generic `print` function.

Best regards.