### PR TITLE
Expression vectors no sidebar

### DIFF
--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -147,7 +147,6 @@ source2 <- function(path, env = caller_env()) {
 The real `source()` is considerably more complicated because it can `echo` input and output, and has many other settings that control its behaviour.
 
 
-::: sidebar
 **Expression vectors**
 \index{expression vectors}
 
@@ -162,7 +161,6 @@ source3 <- function(file, env = parent.frame()) {
 ```
 
 While `source3()` is considerably more concise than `source2()`, this is the only advantage to expression vectors. Overall I don't believe this benefit outweighs the cost of introducing a new data structure, and hence this book avoids the use of expression vectors.
-:::
 
 
 ### Gotcha: `function()`


### PR DESCRIPTION
Having the **Expression vectors** section in a _sidebar_ makes it a bit more difficult to read.