### PR TITLE
Add omitted argument name to 19.7.5 exercise 1

### DIFF
--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -1181,7 +1181,7 @@ Functions like `curve()` that use an expression containing a pronoun are known a
 
 1.  In the linear-model example, we could replace the `expr()` in 
     `reduce(summands, ~ expr(!!.x + !!.y))` with `call2()`:
-    `reduce(summands, call2, "+")`. Compare and contrast the two 
+    `reduce(summands, call2, .fn = "+")`. Compare and contrast the two 
     approaches. Which do you think is easier to read?
 
 1.  Re-implement the Box-Cox transform defined below using unquoting and


### PR DESCRIPTION
Working through the chapter 19 exercises, I encountered an error doing the first exercise of section 19.7.5. I tried replacing the last line of the provided function `linear` with `reduce(summands, call2, "+")`, as suggested. Running the code below triggered an error:

```r
library(rlang)
library(purrr)

linear <- function(var, val) {
  var <- ensym(var)
  coef_name <- map(seq_along(val[-1]), ~ expr((!!var)[[!!.x]]))

  summands <- map2(val[-1], coef_name, ~ expr((!!.x * !!.y)))
  summands <- c(val[[1]], summands)

  reduce(summands, call2, "+")
}

linear(x, c(10, 5, -4))
```

```r
Attaching package: ‘purrr’

The following objects are masked from ‘package:rlang’:

    %@%, as_function, flatten, flatten_chr, flatten_dbl, flatten_int,
    flatten_lgl, flatten_raw, invoke, splice

Error in `fn()`:
! Can't create call to non-callable object
Backtrace:
    ▆
 1. ├─global linear(x, c(10, 5, -4))
 2. │ └─purrr::reduce(summands, call2, "+")
 3. │   └─purrr:::reduce_impl(.x, .f, ..., .init = .init, .dir = .dir)
 4. │     └─rlang fn(out, elt, ...)
 5. └─rlang::abort(message = message)

```

It seems that `reduce` passes one element of `summands` to `call2`'s `.fn` argument, and the other element and "+" to  its `...`. Changing the line to `reduce(summands, call2, .fn = "+")` so the argument is matched correctly fixes the issue, and the code returns the correct result. This pull request changes the suggested line in the exercise accordingly. Since the question is about code readability rather than argument matching, I reasoned the behavior was unintended. 

My sessionInfo() output:

```r
> sessionInfo()
R version 4.2.0 (2022-04-22)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Ubuntu 20.04.4 LTS

Matrix products: default
BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.9.0
LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.9.0

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C              
 [3] LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
 [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8   
 [7] LC_PAPER=en_US.UTF-8       LC_NAME=C                 
 [9] LC_ADDRESS=C               LC_TELEPHONE=C            
[11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] rlang_1.0.1 purrr_0.3.4

loaded via a namespace (and not attached):
[1] compiler_4.2.0 magrittr_2.0.2 cli_3.1.1 
```

I assign the copyright of this contribution to Hadley Wickham.