### PR TITLE
Typo

### DIFF
--- a/Foundations.Rmd
+++ b/Foundations.Rmd
@@ -2,7 +2,7 @@
 
 # Introduction {#foundations-intro  .unnumbered}
 
-To start your journey in mastering R, the following six chapters will help you learn the foundational components of R. I expect that you've already seen many of these pieces before, but you probably have not studied them deeply. To help check your existing knowledge, each chapter starts with a quiz; if you get all the questions right, feel free to skip to the next chapter!
+To start your journey in mastering R, the following seven chapters will help you learn the foundational components of R. I expect that you've already seen many of these pieces before, but you probably have not studied them deeply. To help check your existing knowledge, each chapter starts with a quiz; if you get all the questions right, feel free to skip to the next chapter!
 
 1.  Chapter \@ref(names-values) teaches you about an important distinction
     that you probably haven't thought deeply about: the difference between an 


### PR DESCRIPTION
The foundations talk about `seven` chapters but it is mentioned as `six` in the introduction paragraph. 