### PR TITLE
Correct spelling error in Quotation.Rmd: spatting => splatting

### DIFF
--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -786,7 +786,7 @@ One way to think about these problems is to draw explicit parallels to quasiquot
     dplyr::bind_rows(!!!dfs)
     ```
     
-    When used in this context, the behaviour of `!!!` is known as "spatting" in 
+    When used in this context, the behaviour of `!!!` is known as "splatting" in 
     Ruby, Go, PHP, and Julia. It is closely related to `*args` (star-args) and
     `**kwarg` (star-star-kwargs) in Python, which are sometimes called argument
     unpacking. 


### PR DESCRIPTION
Minor spelling / terminology correction - spatting => splatting.

Per contribution guidelines: I assign the copyright of this contribution to Hadley Wickham.