### PR TITLE
Correct purrr function name

### DIFF
--- a/Function-operators.Rmd
+++ b/Function-operators.Rmd
@@ -156,7 +156,7 @@ purrr comes with three other function operators in a similar vein:
 * `quietly()`: turns output, messages, and warning side-effects into
   `output`, `message`, and `warning` components of the output.
 
-* `auto_browser()`: automatically executes `browser()` inside the 
+* `auto_browse()`: automatically executes `browser()` inside the 
   function when there's an error.
 
 See their documentation for more details.


### PR DESCRIPTION
auto_browser -> auto_browse

I assign the copyright of this contribution to Hadley Wickham