### PR TITLE
Fix typo

### DIFF
--- a/Function-factories.Rmd
+++ b/Function-factories.Rmd
@@ -138,7 +138,7 @@ There's a lot going on this diagram and some of the details aren't that importan
 knitr::include_graphics("diagrams/function-factories/power-simple.png")
 ```
 
-This view, which focuses on the environments, doesn't show any direct link between `cube()` and `square()`. That's because the link is the through the body of the function, which is identical for both, but is not shown in this diagram.
+This view, which focuses on the environments, doesn't show any direct link between `cube()` and `square()`. That's because the link is through the body of the function, which is identical for both, but is not shown in this diagram.
 
 To finish up, let's look at the execution environment of `square(10)`. When `square()` executes `x ^ exp` it finds `x` in the execution environment and `exp` in its enclosing environment.
 


### PR DESCRIPTION
`the link is the through` → ` the link is through`