### PR TITLE
Edit in Subsetting chapter

### DIFF
--- a/Subsetting.Rmd
+++ b/Subsetting.Rmd
@@ -390,7 +390,7 @@ Doing so reinforces the expectation that you are getting and setting individual 
 ### `$`
 \indexc{\$}
 
-`$` is a shorthand operator: `x$y` is roughly equivalent to `x[["y"]]`.  It's often used to access variables in a data frame, as in `mtcars$cyl` or `diamonds$carat`. One common mistake with `$` is to use it when you have the name of a column stored in a variable:
+`$` is a shorthand operator: `x$y` is roughly equivalent to `x[["y", exact = FALSE]]`.  It's often used to access variables in a data frame, as in `mtcars$cyl` or `diamonds$carat`. One common mistake with `$` is to use it when you have the name of a column stored in a variable:
 
 ```{r, include = FALSE}
 options(warnPartialMatchDollar = FALSE)
@@ -405,7 +405,7 @@ mtcars$var
 mtcars[[var]]
 ```
 
-The one important difference between `$` and `[[` is that `$` does (left-to-right) partial matching:
+The one important difference between `$` and `[[` is that `$` automatically does (left-to-right) partial matching without warning:
 
 ```{r}
 x <- list(abc = 1)


### PR DESCRIPTION
A small edit to note that `[[` can do partial matching too, but not by default.