### PR TITLE
Conditions of length greater than 1 result in an error since R 4.2.0

### DIFF
--- a/Control-flow.Rmd
+++ b/Control-flow.Rmd
@@ -94,24 +94,26 @@ The `condition` should evaluate to a single `TRUE` or `FALSE`. Most other inputs
 if ("x") 1
 if (logical()) 1
 if (NA) 1
-```
-
-The exception is a logical vector of length greater than 1, which generates a warning:
-
-```{r, include = FALSE}
-Sys.setenv("_R_CHECK_LENGTH_1_CONDITION_" = "false")
-```
-
-```{r}
 if (c(TRUE, FALSE)) 1
 ```
 
-In R 3.5.0 and greater, thanks to [Henrik Bengtsson](https://github.com/HenrikBengtsson/Wishlist-for-R/issues/38), you can turn this into an error by setting an environment variable:
+Before R 4.2.0 the exception to this rule were logical vectors of length greater than 1. Those used to generate a warning only:
+```
+if (c(TRUE, FALSE)) 1
+#> Warning in if (c(TRUE, FALSE)) 1: the condition has length > 1 and only the
+#> first element will be used
+#> [1] 1
+```
+
+In R 3.5.0 and greater, thanks to  [Henrik Bengtsson](https://github.com/HenrikBengtsson/Wishlist-for-R/issues/38), you were able to turn this into an error by setting an environment variable:
 
 ```{r, error = TRUE}
 Sys.setenv("_R_CHECK_LENGTH_1_CONDITION_" = "true")
 if (c(TRUE, FALSE)) 1
 ```
+
+As of R 4.2.0 vectors of length greater than 1 result in an error, independently of the value of `_R_CHECK_LENGTH_1_CONDITION_`. 
+
 
 I think this is good practice as it reveals a clear mistake that you might otherwise miss if it were only shown as a warning.
 


### PR DESCRIPTION
Any conditions in if statements that have a length of > 1 are considered errors by default since R 4.2.0. Thanks, @HenrikBengtsson! 
https://github.com/HenrikBengtsson/Wishlist-for-R/issues/38

The value of _R_CHECK_LENGTH_1_CONDITION_ will no longer be checked.  This means that regardless of whether the condition is set or not, the command if (c(TRUE, FALSE)) 1
will result in an error.

I assign the copyright of this contribution to Hadley Wickham