### PR TITLE
wrap() has been removed from knitr 1.40 in favor of sew()

### DIFF
--- a/common.R
+++ b/common.R
@@ -42,7 +42,7 @@ knitr::knit_hooks$set(
 )
 
 # Make error messages closer to base R
-registerS3method("wrap", "error", envir = asNamespace("knitr"),
+registerS3method("sew", "error", envir = asNamespace("knitr"),
   function(x, options) {
     msg <- conditionMessage(x)
 


### PR DESCRIPTION
From NEWS.md: https://github.com/yihui/knitr/blob/master/NEWS.md
> The internal function knitr:::wrap() has been removed from this package. If you rely on this function, you will have to use the exported function knitr::sew() instead.

And I sign off on the IP :)