### PR TITLE
Add argument to handler functions

### DIFF
--- a/beyond-exception-handling.Rmd
+++ b/beyond-exception-handling.Rmd
@@ -424,7 +424,7 @@ eponymous restart. Such functions are called *restart functions*. You
 could define a restart function for `skip_log_entry` like this:
 
 ```{r}
-skip_log_entry <- function() invokeRestart("skip_log_entry")
+skip_log_entry <- function(e) invokeRestart("skip_log_entry")
 ```
 
 Then you could change the definition of `log_analyzer()` to this:
@@ -451,7 +451,7 @@ code that doesn't have a `skip_log_entry` restart established, you could
 change the `skip_log_entry` function to this:
 
 ```{r}
-skip_log_entry <- function() {
+skip_log_entry <- function(e) {
   r <- findRestart("skip_log_entry") 
   if (is.null(r)) return()
   


### PR DESCRIPTION
They are used directly inside `withCallingHandlers()`, otherwise an error occurs.