### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Advanced R
 
-[![build-book](https://github.com/hadley/adv-r/actions/workflows/build-book.yaml/badge.svg?branch=master&event=push)](https://github.com/hadley/adv-r/actions/workflows/build-book.yaml)
+[![bookdown](https://github.com/hadley/adv-r/actions/workflows/bookdown.yaml/badge.svg?event=push)](https://github.com/hadley/adv-r/actions/workflows/bookdown.yaml)
 
 This is code and text behind the [Advanced R](http://adv-r.hadley.nz)
 book.  The site is built with [bookdown](https://bookdown.org/yihui/bookdown/).


### PR DESCRIPTION
the workflow was renamed by [this commit](https://github.com/hadley/adv-r/commit/9081bcd221355ce358a6a1031f04f9c15daf36a3), so the badge has to be adjusted as well.