### PR TITLE
Fix typo: lets -> let's

### DIFF
--- a/S3.Rmd
+++ b/S3.Rmd
@@ -233,7 +233,7 @@ The constructor should follow three principles:
 
 * Check the type of the base object and the types of each attribute.
 
-I'll illustrate these ideas by creating constructors for base classes[^base-constructors] that you're already familiar with. To start, lets make a constructor for the simplest S3 class: `Date`. A `Date` is just a double with a single attribute: its `class` is "Date". This makes for a very simple constructor:
+I'll illustrate these ideas by creating constructors for base classes[^base-constructors] that you're already familiar with. To start, let's make a constructor for the simplest S3 class: `Date`. A `Date` is just a double with a single attribute: its `class` is "Date". This makes for a very simple constructor:
 
 [^base-constructors]: Recent versions of R have `.Date()`, `.difftime()`, `.POSIXct()`, and `.POSIXlt()` constructors but they are internal, not well documented, and do not follow the principles that I recommend.
 


### PR DESCRIPTION
Simple typo: instead of "lets make a constructor [...]", write "let's make a constructor".

I assign the copyright of this contribution to Hadley Wickham.