### PR TITLE
Update hyperlink reference in Perf-improve.Rmd

### DIFF
--- a/Perf-improve.Rmd
+++ b/Perf-improve.Rmd
@@ -361,7 +361,7 @@ Modifying an object in a loop, e.g., `x[i] <- y`, can also create a copy, depend
 
 ## Case study: t-test {#t-test}
 
-The following case study shows how to make t-tests faster using some of the techniques described above. It's based on an example in [_Computing thousands of test statistics simultaneously in R_](http://stat-computing.org/newsletter/issues/scgn-18-1.pdf) by Holger Schwender and Tina Müller. I thoroughly recommend reading the paper in full to see the same idea applied to other tests.
+The following case study shows how to make t-tests faster using some of the techniques described above. It's based on an example in [_Computing thousands of test statistics simultaneously in R_](https://web.archive.org/web/20220119164311/http://stat-computing.org/newsletter/issues/scgn-18-1.pdf) by Holger Schwender and Tina Müller. I thoroughly recommend reading the paper in full to see the same idea applied to other tests.
 
 Imagine we have run 1000 experiments (rows), each of which collects data on 50 individuals (columns). The first 25 individuals in each experiment are assigned to group 1 and the rest to group 2. We'll first generate some random data to represent this problem:
 


### PR DESCRIPTION
_Computing Thousands of Test Statistics Simultaneously in R_ is now a dead link: http://stat-computing.org/newsletter/issues/scgn-18-1.pdf

Use the archive.org version that has been archived instead.