### PR TITLE
Fix broken Link to the Tidyverse style guide in Conditions.Rmd

### DIFF
--- a/Conditions.Rmd
+++ b/Conditions.Rmd
@@ -130,7 +130,7 @@ f()
 
 (NB: `stop()` pastes together multiple inputs, while `abort()` does not. To create complex error messages with abort, I recommend using `glue::glue()`. This allows us to use other arguments to `abort()` for useful features that you'll learn about in Section \@ref(custom-conditions).)
 
-The best error messages tell you what is wrong and point you in the right direction to fix the problem. Writing good error messages is hard because errors usually occur when the user has a flawed mental model of the function. As a developer, it's hard to imagine how the user might be thinking incorrectly about your function, and thus it's hard to write a message that will steer the user in the correct direction. That said, the tidyverse style guide discusses a few general principles that we have found useful: <http://style.tidyverse.org/error-messages.html>.
+The best error messages tell you what is wrong and point you in the right direction to fix the problem. Writing good error messages is hard because errors usually occur when the user has a flawed mental model of the function. As a developer, it's hard to imagine how the user might be thinking incorrectly about your function, and thus it's hard to write a message that will steer the user in the correct direction. That said, the tidyverse style guide discusses a few general principles that we have found useful: <http://style.tidyverse.org/errors.html>.
 
 ### Warnings
 \index{warnings}


### PR DESCRIPTION
A change in the [Tidiverse style guide](https://github.com/tidyverse/style) appears to have changed the URL of the "Error messages" part (I'm not exactly sure what has caused this)

from  
http://style.tidyverse.org/error-messages.html  
to  
http://style.tidyverse.org/errors.html

This looks like the only link from http://style.tidyverse.org/ in this book that is affected.